### PR TITLE
548 rsync exclude

### DIFF
--- a/data_ingestion_template.yaml.template
+++ b/data_ingestion_template.yaml.template
@@ -71,10 +71,6 @@ CHUNK_FILE: chunks.txt
 # for 'find' and 'ls' operations
 FILE_COUNT: 1000000
 
-# total number of input data files with FILE_TYPE extension. this can be obtained by running the following command on the source directory
-# 'find <source_dir> -type f -name "*.<FILE_TYPE>" | wc -l'
-FILE_TYPE_COUNT: 1000000
-
 # total number of bytes to be transferred. this can be obtained by running the following command on the source directory
 # 'find <source_dir> -type f -name "*.dcm" -o -name "*.mha" | xargs du -ac'
 DATA_SIZE: 291337979

--- a/data_ingestion_template_schema.yml
+++ b/data_ingestion_template_schema.yml
@@ -40,8 +40,6 @@ CHUNK_FILE: any(str(required=True))
 
 FILE_COUNT: int(required=True, min=1)
 
-FILE_TYPE_COUNT: int(required=True, min=1)
-
 DATA_SIZE: int(required=True, min=0)
 
 # The  suffixes  are  as  follows:  "K" (or "KiB") is a kibibyte (1024), "M" (or "MiB") is a mebibyte

--- a/data_processing/radiology/proxy_table/generate.py
+++ b/data_processing/radiology/proxy_table/generate.py
@@ -203,10 +203,10 @@ def create_proxy_table(config_file):
     processed_count = header.count()
     logger.info("Processed {} dicom headers out of total {} dicom files".format(processed_count,
                                                                                 cfg.get_value(name=DATA_CFG,
-                                                                                                    jsonpath='FILE_TYPE_COUNT')))
+                                                                                                    jsonpath='FILE_COUNT')))
 
     # validate and show created dataset
-    if processed_count != int(cfg.get_value(name=DATA_CFG, jsonpath='FILE_TYPE_COUNT')):
+    if processed_count != int(cfg.get_value(name=DATA_CFG, jsonpath='FILE_COUNT')):
         exit_code = 1
     df = spark.read.format(cfg.get_value(name=DATA_CFG, jsonpath='FORMAT_TYPE')).load(dicom_path)
     df.printSchema()

--- a/data_processing/radiology/proxy_table/transfer_files.sh
+++ b/data_processing/radiology/proxy_table/transfer_files.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 ########################### setup pre-conditions ###########################
 set -x
 LOG_FILE=transfer_files.log
@@ -14,7 +15,6 @@ echo "$(date '+%Y-%m-%d %H:%M:%S') INFO: RAW_DATA_PATH = $RAW_DATA_PATH" >> $LOG
 echo "$(date '+%Y-%m-%d %H:%M:%S') INFO: FILE_COUNT = $FILE_COUNT" >> $LOG_FILE;
 echo "$(date '+%Y-%m-%d %H:%M:%S') INFO: DATA_SIZE = $DATA_SIZE" >> $LOG_FILE;
 
-# todo: make keys in ingestion template all caps
 
 # validate env vars - check if they exist
 [ "${BWLIMIT}" ]
@@ -60,7 +60,7 @@ num_procs=${bw%?}
 #   process left off logic)
 time cat $CHUNK_FILE | xargs -I {} -P $num_procs -n 1 \
 rsync -ahW --delete --stats --log-file=$LOG_FILE \
---exclude='*.'{$EXCLUDES} \
+$EXCLUDES \
 --bwlimit=$BWLIMIT  \
 $HOST:$SOURCE_PATH/{} $RAW_DATA_PATH
 
@@ -90,7 +90,7 @@ else
 fi
 
 # verify and log transfer data size (bytes)
-data_size=$(find $RAW_DATA_PATH -type d | xargs du -s | cut -f1)
+data_size=$(find $RAW_DATA_PATH -type d | xargs du -d 0 | head -n 1 | cut -f1)
 [ $DATA_SIZE -eq $data_size ];
 
 let exit_code=$?+$exit_code

--- a/data_processing/radiology/proxy_table/transfer_files.sh
+++ b/data_processing/radiology/proxy_table/transfer_files.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# transfers data from a remote source to a destination.
+# For inputs, see preconditions below for required environment variables.
+# For usage, see tests/data_processing/radiology/proxy_table/test_transfer_files.py.
+
 ########################### setup pre-conditions ###########################
 set -x
 LOG_FILE=transfer_files.log
@@ -8,7 +13,7 @@ echo "$(date '+%Y-%m-%d %H:%M:%S') INFO: >>>> writing data transfer logs to $LOG
 echo "$(date '+%Y-%m-%d %H:%M:%S') INFO: Running data_processing/radiology/proxy_table/transfer_files.sh with - " >> $LOG_FILE;
 echo "$(date '+%Y-%m-%d %H:%M:%S') INFO: BWLIMIT = $BWLIMIT" >> $LOG_FILE;
 echo "$(date '+%Y-%m-%d %H:%M:%S') INFO: CHUNK_FILE = $CHUNK_FILE" >> $LOG_FILE;
-echo "$(date '+%Y-%m-%d %H:%M:%S') INFO: EXCLUDES = $EXCLUDES" >> $LOG_FILE;
+echo "$(date '+%Y-%m-%d %H:%M:%S') INFO: INCLUDES = $INCLUDE" >> $LOG_FILE;
 echo "$(date '+%Y-%m-%d %H:%M:%S') INFO: HOST = $HOST" >> $LOG_FILE;
 echo "$(date '+%Y-%m-%d %H:%M:%S') INFO: SOURCE_PATH = $SOURCE_PATH" >> $LOG_FILE;
 echo "$(date '+%Y-%m-%d %H:%M:%S') INFO: RAW_DATA_PATH = $RAW_DATA_PATH" >> $LOG_FILE;
@@ -20,6 +25,8 @@ echo "$(date '+%Y-%m-%d %H:%M:%S') INFO: DATA_SIZE = $DATA_SIZE" >> $LOG_FILE;
 [ "${BWLIMIT}" ]
 let exit_code=$?+$exit_code
 [ "${CHUNK_FILE}" ]
+let exit_code=$?+$exit_code
+[ "${INCLUDE}" ]
 let exit_code=$?+$exit_code
 [ "${HOST}" ]
 let exit_code=$?+$exit_code
@@ -54,13 +61,13 @@ num_procs=${bw%?}
 # - delete any files in the destination location that are not in the source location
 # - output stats at the end
 # - output a log file
-# - exclude transfer of any files with the excluded file extensions
+# - include transfer of any files with the included file extensions
 # - limit each process's network utilization to the specified bwlimit
 # - if files already exist in destination dir, then they are not overwritten (continue from where
 #   process left off logic)
 time cat $CHUNK_FILE | xargs -I {} -P $num_procs -n 1 \
 rsync -ahW --delete --stats --log-file=$LOG_FILE \
-$EXCLUDES \
+$INCLUDE --include=*/ --exclude=* \
 --bwlimit=$BWLIMIT  \
 $HOST:$SOURCE_PATH/{} $RAW_DATA_PATH
 

--- a/tests/data_processing/common/test_data_ingestion_template.yml
+++ b/tests/data_processing/common/test_data_ingestion_template.yml
@@ -71,10 +71,6 @@ CHUNK_FILE: chunks.txt
 # for 'find' and 'ls' operations
 FILE_COUNT: 1000000
 
-# total number of input data files with FILE_TYPE extension. this can be obtained by running the following command on the source directory
-# 'find <source_dir> -type f -name "*.<FILE_TYPE>" | wc -l'
-FILE_TYPE_COUNT: 1000000
-
 # total number of bytes to be transferred. this can be obtained by running the following command on the source directory
 # 'find <source_dir> -type f -name "*.dcm" -o -name "*.mha" | xargs du -ac'
 DATA_SIZE: 291337979

--- a/tests/data_processing/data_ingestion_template_valid.yml
+++ b/tests/data_processing/data_ingestion_template_valid.yml
@@ -67,9 +67,6 @@ CHUNK_FILE: chunks.txt
 # 'find <source_dir> -type f -name "*.dcm" -o -name "*.mha" | wc -l'
 FILE_COUNT: 1
 
-# total number of input data files with FILE_TYPE extension.
-FILE_TYPE_COUNT: 1
-
 # total number of bytes to be transfered. this can be obtained by running the following command on the source directory
 # 'find <source_dir> -type f -name "*.dcm" -o -name "*.mha" | xargs du -ac'
 DATA_SIZE: 291337979

--- a/tests/data_processing/radiology/proxy_table/test_data/chunk_file1.txt
+++ b/tests/data_processing/radiology/proxy_table/test_data/chunk_file1.txt
@@ -1,4 +1,3 @@
 test1.dcm
-test1.mha
-test1.mhd
-test1.raw
+nested_dir/test2.dcm
+nested_dir/double_nested_dir/test3.dcm

--- a/tests/data_processing/radiology/proxy_table/test_data/source/nested_dir/double_nested_dir/test3.dcm
+++ b/tests/data_processing/radiology/proxy_table/test_data/source/nested_dir/double_nested_dir/test3.dcm
@@ -1,0 +1,1 @@
+test dcm file

--- a/tests/data_processing/radiology/proxy_table/test_data/source/nested_dir/double_nested_dir/test3.mha
+++ b/tests/data_processing/radiology/proxy_table/test_data/source/nested_dir/double_nested_dir/test3.mha
@@ -1,0 +1,1 @@
+test mha file

--- a/tests/data_processing/radiology/proxy_table/test_data/source/nested_dir/double_nested_dir/test3.mhd
+++ b/tests/data_processing/radiology/proxy_table/test_data/source/nested_dir/double_nested_dir/test3.mhd
@@ -1,0 +1,1 @@
+test mhd file

--- a/tests/data_processing/radiology/proxy_table/test_data/source/nested_dir/double_nested_dir/test3.raw
+++ b/tests/data_processing/radiology/proxy_table/test_data/source/nested_dir/double_nested_dir/test3.raw
@@ -1,0 +1,1 @@
+test raw file

--- a/tests/data_processing/radiology/proxy_table/test_data/source/nested_dir/test2.dcm
+++ b/tests/data_processing/radiology/proxy_table/test_data/source/nested_dir/test2.dcm
@@ -1,0 +1,1 @@
+test dcm file

--- a/tests/data_processing/radiology/proxy_table/test_data/source/nested_dir/test2.mha
+++ b/tests/data_processing/radiology/proxy_table/test_data/source/nested_dir/test2.mha
@@ -1,0 +1,1 @@
+test mha file

--- a/tests/data_processing/radiology/proxy_table/test_data/source/nested_dir/test2.mhd
+++ b/tests/data_processing/radiology/proxy_table/test_data/source/nested_dir/test2.mhd
@@ -1,0 +1,1 @@
+test mhd file

--- a/tests/data_processing/radiology/proxy_table/test_data/source/nested_dir/test2.raw
+++ b/tests/data_processing/radiology/proxy_table/test_data/source/nested_dir/test2.raw
@@ -1,0 +1,1 @@
+test raw file

--- a/tests/data_processing/radiology/proxy_table/test_transfer_files.py
+++ b/tests/data_processing/radiology/proxy_table/test_transfer_files.py
@@ -72,15 +72,13 @@ def test_transfer_files(env):
 
 
 
-
-# @todo: this test fails on excludes. A better pattern is needed in the rsync exclude argument
 def test_transfer_files_with_excludes(env):
     os.environ['CHUNK_FILE'] = 'tests/data_processing/radiology/proxy_table/test_data/chunk_file2.txt'
     os.environ['SOURCE_PATH'] = os.getcwd() + \
                                 '/tests/data_processing/radiology/proxy_table/test_data'
-    os.environ['EXCLUDES'] = 'raw,mhd'
-    os.environ['FILE_COUNT'] = '2'
-    os.environ['DATA_SIZE'] = '16'
+    os.environ['EXCLUDES'] = '--exclude=*.raw --exclude=*.mhd'
+    os.environ['FILE_COUNT'] = '4'
+    os.environ['DATA_SIZE'] = '32'
 
     transfer_cmd = ["time", "./data_processing/radiology/proxy_table/transfer_files.sh"]
 

--- a/tests/data_processing/radiology/proxy_table/test_transfer_files.py
+++ b/tests/data_processing/radiology/proxy_table/test_transfer_files.py
@@ -48,12 +48,16 @@ def env():
 
 
 '''
-def test_transfer_files(env):
+def test_transfer_files_1(env):
+    #
+    # Chunk file points to a files and include limits to one file types
+    #
     os.environ['CHUNK_FILE'] = 'tests/data_processing/radiology/proxy_table/test_data/chunk_file1.txt'
     os.environ['SOURCE_PATH'] = os.getcwd() + \
-                                '/tests/data_processing/radiology/proxy_table/test_data/source'
-    os.environ['FILE_COUNT'] = '4'
-    os.environ['DATA_SIZE'] = '32'
+                                '/tests/data_processing/radiology/proxy_table/test_data/source/'
+    os.environ['INCLUDE'] = '--include=*.dcm'
+    os.environ['FILE_COUNT'] = '3'
+    os.environ['DATA_SIZE'] = '24'
 
     transfer_cmd = ["time", "./data_processing/radiology/proxy_table/transfer_files.sh"]
 
@@ -65,20 +69,30 @@ def test_transfer_files(env):
 
     assert(exit_code == 0)
     assert os.path.exists(os.getenv('RAW_DATA_PATH'))
+
     assert os.path.exists(os.getenv('RAW_DATA_PATH')+'/test1.dcm')
-    assert os.path.exists(os.getenv('RAW_DATA_PATH')+'/test1.mha')
-    assert os.path.exists(os.getenv('RAW_DATA_PATH')+'/test1.mhd')
-    assert os.path.exists(os.getenv('RAW_DATA_PATH')+'/test1.raw')
+    assert os.path.exists(os.getenv('RAW_DATA_PATH') + '/test2.dcm')
+    assert os.path.exists(os.getenv('RAW_DATA_PATH') + '/test3.dcm')
+
+    assert not os.path.exists(os.getenv('RAW_DATA_PATH')+'/test1.mha')
+    assert not os.path.exists(os.getenv('RAW_DATA_PATH')+'/test1.mhd')
+    assert not os.path.exists(os.getenv('RAW_DATA_PATH')+'/test1.raw')
+
+    assert not os.path.exists(os.getenv('RAW_DATA_PATH')+'/nested_dir')
+'''
 
 
-
-def test_transfer_files_with_excludes(env):
+'''
+def test_transfer_files_2(env):
+    #
+    # Chunk file points to a dir and include limits to two file types
+    #
     os.environ['CHUNK_FILE'] = 'tests/data_processing/radiology/proxy_table/test_data/chunk_file2.txt'
     os.environ['SOURCE_PATH'] = os.getcwd() + \
                                 '/tests/data_processing/radiology/proxy_table/test_data'
-    os.environ['EXCLUDES'] = '--exclude=*.raw --exclude=*.mhd'
-    os.environ['FILE_COUNT'] = '4'
-    os.environ['DATA_SIZE'] = '32'
+    os.environ['INCLUDE'] = '--include=*.dcm --include=*.mha'
+    os.environ['FILE_COUNT'] = '6'
+    os.environ['DATA_SIZE'] = '48'
 
     transfer_cmd = ["time", "./data_processing/radiology/proxy_table/transfer_files.sh"]
 
@@ -90,8 +104,19 @@ def test_transfer_files_with_excludes(env):
 
     assert(exit_code == 0)
     assert os.path.exists(os.getenv('RAW_DATA_PATH'))
+
     assert os.path.exists(os.getenv('RAW_DATA_PATH')+'/source/test1.dcm')
     assert os.path.exists(os.getenv('RAW_DATA_PATH')+'/source/test1.mha')
     assert not os.path.exists(os.getenv('RAW_DATA_PATH')+'/source/test1.mhd')
     assert not os.path.exists(os.getenv('RAW_DATA_PATH')+'/source/test1.raw')
+
+    assert os.path.exists(os.getenv('RAW_DATA_PATH') + '/source/nested_dir/test2.dcm')
+    assert os.path.exists(os.getenv('RAW_DATA_PATH') + '/source/nested_dir/test2.mha')
+    assert not os.path.exists(os.getenv('RAW_DATA_PATH') + '/source/nested_dir/test2.mhd')
+    assert not os.path.exists(os.getenv('RAW_DATA_PATH') + '/source/nested_dir/test2.raw')
+
+    assert os.path.exists(os.getenv('RAW_DATA_PATH') + '/source/nested_dir/double_nested_dir/test3.dcm')
+    assert os.path.exists(os.getenv('RAW_DATA_PATH') + '/source/nested_dir/double_nested_dir/test3.mha')
+    assert not os.path.exists(os.getenv('RAW_DATA_PATH') + '/source/nested_dir/double_nested_dir/test3.mhd')
+    assert not os.path.exists(os.getenv('RAW_DATA_PATH') + '/source/nested_dir/double_nested_dir/test3.raw')
 '''


### PR DESCRIPTION
exclude option in transfer-files now works. See unit test to learn how to use the option. 

https://github.com/msk-mind/data-processing/blob/548-rsync-exclude/tests/data_processing/radiology/proxy_table/test_transfer_files.py#L79

As a consequence, TYPE_FILE_COUNT kvp is removed from the data ingestion template since files that are not needed can be excluded