### PR TITLE
add driver maxresult size in config

### DIFF
--- a/config.yaml.template
+++ b/config.yaml.template
@@ -24,3 +24,5 @@ spark_application_config:
   - spark.executor.pyspark.memory: 30g
 
   - spark.sql.shuffle.partitions: 300
+
+  - spark.driver.maxResultSize: 2g

--- a/data_processing/common/sparksession.py
+++ b/data_processing/common/sparksession.py
@@ -23,6 +23,8 @@ class SparkConfig:
 			cfg.get_value(path=config_name+'::$.spark_application_config[:4]["spark.executor.pyspark.memory"]')
 		spark_sql_shuffle_partitions = \
 			cfg.get_value(path=config_name+'::$.spark_application_config[:5]["spark.sql.shuffle.partitions"]')
+		spark_driver_maxresultsize = \
+			cfg.get_value(path=config_name+'::$.spark_application_config[:6]["spark.driver.maxResultSize"]')
 
 		return SparkSession.builder \
 			.appName(app_name) \
@@ -40,6 +42,7 @@ class SparkConfig:
 			.config("spark.cores.max", spark_cores_max) \
 			.config("spark.executor.pyspark.memory", spark_executor_pyspark_memory) \
 			.config("spark.sql.shuffle.partitions", spark_sql_shuffle_partitions) \
+			.config("spark.driver.maxResultSize", spark_driver_maxresultsize) \
 			.config("fs.defaultFS", "file:///") \
 			.config("spark.driver.extraJavaOptions", "-Dio.netty.tryReflectionSetAccessible=true") \
 			.config("spark.executor.extraJavaOptions", "-Dio.netty.tryReflectionSetAccessible=true") \

--- a/tests/data_processing/common/test_config.yml
+++ b/tests/data_processing/common/test_config.yml
@@ -20,3 +20,4 @@ spark_application_config:
 
   - spark.sql.shuffle.partitions: 300
 
+  - spark.driver.maxResultSize: 1g

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -19,3 +19,5 @@ spark_application_config:
   - spark.executor.pyspark.memory: 6g
 
   - spark.sql.shuffle.partitions: 30
+
+  - spark.driver.maxResultSize: 1g


### PR DESCRIPTION
operations like topandas() sometimes fail with collect data exceeding spark.driver.maxresultsize limit (default 1g)

added this in the config to give us the flexibility to increase this if needed.