### PR TITLE
590 api docs

### DIFF
--- a/data_processing/cohortManager/cohortManager.py
+++ b/data_processing/cohortManager/cohortManager.py
@@ -32,46 +32,165 @@ HOST = os.environ['HOSTNAME']
 # Routes to list things
 # ==================================================================================================
 
-# List all the patients
-@api.route('/mind/api/v1/patient/list/<cohort_id>', 
-    methods=['GET'],
-    doc={"description": "List all the patients and recursively, their cases, scans, and available data"}
-)
-@api.doc(params={'cohort_id': 'Cohort Identifier'})
-class listPatients(Resource):
-    def get(self, cohort_id):
-        """ Retrieve patient listing """
+# # List all the patients
+# @api.route('/mind/api/v1/patient/list/<cohort_id>', 
+#     methods=['GET'],
+#     doc={"description": "List all the patients and recursively, their cases"}
+# )
+# @api.doc(params={'cohort_id': 'Cohort Identifier'})
+# class listPatients(Resource):
+#     def get(self, cohort_id):
+#         """ Retrieve patient listing """
 
-        # Matches (cohort <include> patients)
-        res = conn.query(f"""
-            MATCH (co:cohort{{CohortID:'{cohort_id}'}})-[:INCLUDE]-(px:patient) 
-            RETURN px
+#         # Matches (cohort <include> patients)
+#         res = conn.query(f"""
+#             MATCH (co:cohort{{CohortID:'{cohort_id}'}})-[:INCLUDE]-(px:patient) 
+#             RETURN px
+#             """
+#         )
+
+#         all_px = []
+#         for rec in res:
+#             px_dict = rec.data()['px']
+#             patient_id = px_dict['PatientID']
+#             px_dict['cases'] = requests.get(f'http://{HOST}:5004/mind/api/v1/case/list/{cohort_id}/{patient_id}').json()
+#             all_px.append(px_dict)
+#         return jsonify(all_px)
+
+
+# # List all the scans
+# @api.route('/mind/api/v1/scan/list/<cohort_id>/<patient_id>/<accession_number>', 
+#     methods=['GET'],
+#     doc={"description": "List all scans for a given case accession number and recursively their available data"}
+# )
+# @api.doc(params={'cohort_id': 'Cohort Identifier', 'patient_id': 'Patient Identifier', 'accession_number':'Case Accession Number'})
+# class listScans(Resource):
+#     def get (self, cohort_id, patient_id, accession_number):
+#         """ Retrieve scan listing """
+
+#         # Matches (cohort <include> patients <has_case> cases <has_scan> scan <include> cohort)
+#         res = conn.query(f"""
+#             MATCH (co:cohort{{CohortID:'{cohort_id}'}})
+#             -[:INCLUDE]-(px:patient{{PatientID:'{patient_id}'}})
+#             -[:HAS_CASE]-(cases:accession{{AccessionNumber:'{accession_number}'}})
+#             -[:HAS_SCAN]-(sc:scan)
+#             -[:INCLUDE]-(co)
+#             RETURN sc, id(sc)
+#             """
+#         )
+
+#         all_scan = []
+#         for rec in res:
+#             scan_dict = rec.data()['sc']
+#             scan_id   = rec.data()['id(sc)']
+#             scan_dict['id']   = scan_id
+#             scan_dict['data'] = requests.get(f'http://{HOST}:5004/mind/api/v1/container/scan/{scan_id}').json()
+#             all_scan.append(scan_dict)
+#         return jsonify(all_scan)
+
+# # List all the data
+# @api.route('/mind/api/v1/container/<container_type>/<container_id>', 
+#     methods=['GET'],
+#     doc={"description": "List all available data for a given a scan container"}
+# )
+# @api.doc(params={'container_type': 'Container type, e.g. scan, slide', 'container_id': 'Unique container identifier'})
+# class listContainer(Resource):
+#     def get (self, container_type, container_id):
+#         """ Retrieve container data listing """
+
+#         # Matches (scan <has_data> data)
+#         res = conn.query(f"""
+#             MATCH (sc:{container_type})-[:HAS_DATA]-(data) 
+#             WHERE id(sc)={container_id} 
+#             RETURN data, labels(data)
+#             """
+#         )
+
+#         all_data = []
+#         for rec in res:
+#             data_dict = rec.data()['data']
+#             data_dict['type'] = rec.data()['labels(data)'][0]
+#             all_data.append(data_dict)
+#         return jsonify(all_data)
+
+
+# ==================================================================================================
+# Routes to add manage cohort/study structure (new/add/remove patient)
+# ==================================================================================================
+# Add a new (and include) patient with cases
+@api.route('/mind/api/v1/cohort/<cohort_id>', 
+    methods=['PUT', 'GET'],
+    doc={"description": "Manage the existence of a cohort"}
+)
+@api.doc(
+    params={'cohort_id': 'Cohort Identifier'},
+    responses={200:"Success", 201:"Created successfully", 400:"Bad query", 404:"Cohort not found"}
+)
+class cohort(Resource):
+    def put(self, cohort_id):
+        """ Create new cohort """
+
+        create_res = conn.query(f"""
+            CREATE (co:cohort{{CohortID:'{cohort_id}'}})
+            RETURN co
             """
         )
+        match_res = conn.query(f"""
+            MATCH (co:cohort{{CohortID:'{cohort_id}'}})
+            RETURN co
+            """
+        )
+        if not create_res is None: 
+            return make_response("Created successfully", 201)
+        elif not match_res is None:           
+            return make_response("Cohort already exists", 200)
+        else:
+            return make_response("Bad query", 400)
 
-        all_px = []
-        for rec in res:
-            px_dict = rec.data()['px']
-            patient_id = px_dict['PatientID']
-            px_dict['cases'] = requests.get(f'http://{HOST}:5004/mind/api/v1/case/list/{cohort_id}/{patient_id}').json()
-            all_px.append(px_dict)
-        return jsonify(all_px)
 
-# List all the cases
-@api.route('/mind/api/v1/case/list/<cohort_id>/<patient_id>', 
-    methods=['GET'],
-    doc={"description": "List all cases for a given patient and recursively their scans and available data"}
+    def get(self, cohort_id):
+            """ Retrieve listing for cohort """
+
+            co_res = conn.query(f"""
+                MATCH (co:cohort{{CohortID:'{cohort_id}'}})
+                RETURN co
+                """
+            )
+
+            px_res = conn.query(f"""
+                MATCH (co:cohort{{CohortID:'{cohort_id}'}})-[:INCLUDE]-(px:patient) 
+                RETURN px
+                """
+            )
+
+            # Build summary responses:
+            cohort_summary = co_res[0].data()['co']
+            cohort_summary['Patients'] = []
+            for rec in px_res:
+                px_dict     = rec.data()['px']
+                patient_id  = px_dict['PatientID']
+                px_dict['Patient Accessions'] = requests.get(f'http://{HOST}:5004/mind/api/v1/patient/{patient_id}').json()
+                cohort_summary['Patients'].append(px_dict)
+            
+            if not co_res is None: 
+                return jsonify(cohort_summary)
+            else:           
+                return make_response("Cohort not found", 404)
+
+
+# Get patient listing
+@api.route('/mind/api/v1/patient/<patient_id>', 
+    methods=['GET', 'PUT'],
+    doc={"description": "List all cases for a given patient"}
 )
-@api.doc(params={'cohort_id': 'Cohort Identifier', 'patient_id': 'Patient Identifier'})
+@api.doc(params={'patient_id': 'Patient Identifier'})
 class listCases(Resource):
-    def get(self, cohort_id, patient_id):
-        """ Retrieve case listing """
+    def get(self, patient_id):
+        """ Retrieve case listing for patient"""
 
         # Matches (cohort <include> patients <has_case> cases)
         res = conn.query(f"""
-            MATCH (co:cohort{{CohortID:'{cohort_id}'}})
-            -[:INCLUDE]-(px:patient{{PatientID:'{patient_id}'}})
-            -[:HAS_CASE]-(cases:accession) 
+            MATCH (px:patient{{PatientID:'{patient_id}'}})-[:HAS_CASE]-(cases:accession) 
             RETURN cases
             """
         )
@@ -79,102 +198,75 @@ class listCases(Resource):
         all_case = []
         for rec in res:
             case_dict = rec.data()['cases']
-            accession_number   = case_dict['AccessionNumber']
-            case_dict['scans'] = requests.get(f'http://{HOST}:5004/mind/api/v1/scan/list/{cohort_id}/{patient_id}/{accession_number}').json()
             all_case.append(case_dict)
         return jsonify(all_case)
 
-# List all the scans
-@api.route('/mind/api/v1/scan/list/<cohort_id>/<patient_id>/<accession_number>', 
-    methods=['GET'],
-    doc={"description": "List all scans for a given case accession number and recursively their available data"}
-)
-@api.doc(params={'cohort_id': 'Cohort Identifier', 'patient_id': 'Patient Identifier', 'accession_number':'Case Accession Number'})
-class listScans(Resource):
-    def get (self, cohort_id, patient_id, accession_number):
-        """ Retrieve case listing """
+    def put(self, patient_id):
+            """ Create new patient """
 
-        # Matches (cohort <include> patients <has_case> cases <has_scan> scan <include> cohort)
-        res = conn.query(f"""
-            MATCH (co:cohort{{CohortID:'{cohort_id}'}})
-            -[:INCLUDE]-(px:patient{{PatientID:'{patient_id}'}})
-            -[:HAS_CASE]-(cases:accession{{AccessionNumber:'{accession_number}'}})
-            -[:HAS_SCAN]-(sc:scan)
-            -[:INCLUDE]-(co)
-            RETURN sc, id(sc)
-            """
-        )
-
-        all_scan = []
-        for rec in res:
-            scan_dict = rec.data()['sc']
-            scan_id   = rec.data()['id(sc)']
-            scan_dict['id']   = scan_id
-            scan_dict['data'] = requests.get(f'http://{HOST}:5004/mind/api/v1/container/scan/{scan_id}').json()
-            all_scan.append(scan_dict)
-        return jsonify(all_scan)
-
-# List all the data
-@api.route('/mind/api/v1/container/<container_type>/<container_id>', 
-    methods=['GET'],
-    doc={"description": "List all available data for a given a scan container"}
-)
-@api.doc(params={'container_type': 'Container type, e.g. scan, slide', 'container_id': 'Unique container identifier'})
-class listContainer(Resource):
-    def get (self, container_type, container_id):
-        """ Retrieve container data listing """
-
-        # Matches (scan <has_data> data)
-        res = conn.query(f"""
-            MATCH (sc:{container_type})-[:HAS_DATA]-(data) 
-            WHERE id(sc)={container_id} 
-            RETURN data, labels(data)
-            """
-        )
-
-        all_data = []
-        for rec in res:
-            data_dict = rec.data()['data']
-            data_dict['type'] = rec.data()['labels(data)'][0]
-            all_data.append(data_dict)
-        return jsonify(all_data)
-
-
-# ==================================================================================================
-# Routes to add manage cohort/study structure (new/add/remove patient)
-# ==================================================================================================
+            create_res = conn.query(f"""
+                CREATE (px:patient{{PatientID:'{patient_id}'}})
+                RETURN px
+                """
+            )
+            match_res = conn.query(f"""
+                MATCH (px:patient{{PatientID:'{patient_id}'}})
+                RETURN px
+                """
+            )
+            if not create_res is None: 
+                return make_response("Created successfully", 201)
+            elif not match_res is None:           
+                return make_response("Patient already exists", 200)
+            else:
+                return make_response("Bad query", 400)
 
 # Add a new (and include) patient with cases
-@api.route('/mind/api/v1/patient/new/<cohort_id>/<patient_id>/<case_list>', 
-    methods=['POST'],
-    doc={"description": "Creates a new patient initalized with some cases"}
+@api.route('/mind/api/v1/patient/<patient_id>/<case_list>', 
+    methods=['PUT', 'DELETE'],
+    doc={"description": "Manage the existence of a patients"}
 )
 @api.doc(
-    params={'cohort_id': 'Cohort Identifier', 'patient_id': 'New patient identifier to create', 'case_list':'Comma seperated list of accession numbers to add'},
-    responses={200:"Success", 500:"Failed to add patient"}
+    params={'patient_id': 'New patient identifier to create', 'case_list':'Comma seperated list of accession numbers to add'},
+    responses={200:"Success", 400:"Failed to add patient"}
 )
 class newPatient(Resource):
-    def post(self, cohort_id, patient_id, case_list):
-        """ Create new patient """
+    def put(self, patient_id, case_list):
+        """ Add case listing to patient """
 
         res = conn.query(f"""
             MATCH (cases:accession) 
             WHERE cases.AccessionNumber IN [{case_list}] 
-            MERGE (px:patient{{PatientID:'{patient_id}'}})
-            MERGE (co:cohort{{CohortID:'{cohort_id}'}})
-            MERGE (co)-[r1:INCLUDE]-(px)
-            MERGE (co)-[r2:INCLUDE]-(cases)
-            MERGE (px)-[r3:HAS_CASE]->(cases) 
-            RETURN cases
+            MATCH (px:patient{{PatientID:'{patient_id}'}})
+            MERGE (px)-[r:HAS_CASE]->(cases) 
+            RETURN px, cases, r
             """
         )
-        res = [rec.data()['cases'] for rec in res]
-        if len (res)==0: 
-            return make_response("No cases", 500)
+        print (res)
+        if res is None: 
+            return make_response (f"Bad query", 400)
         else:
-            return make_response (f"Added {patient_id} to {cohort_id} with {len(res)} cases: {res}", 200)
+            dict_res = [rec.data()['cases'] for rec in res]
+            return make_response (f"Added {patient_id} with {len(dict_res)} cases: {dict_res}", 200)
 
-@api.route('/mind/api/v1/patient/<cohort_id>/<patient_id>', 
+    def delete(self, patient_id, case_list):
+        """ Remove case listing from patient """
+
+        res = conn.query(f"""
+            MATCH (px:patient{{PatientID:'{patient_id}'}})-[r:HAS_CASE]->(cases:accession)
+            WHERE cases.AccessionNumber IN [{case_list}] 
+            DELETE r RETURN r
+            """
+        )
+        if res is None: 
+            return make_response (f"No matching cases found for {patient_id}", 400)
+        else:
+            return ("Deleted {} cases from cohort".format(len(res)))
+
+
+
+
+@api.route('/mind/api/v1/cohort/<cohort_id>/<patient_id>', 
     methods=['PUT', 'DELETE'],
     doc={"description": "Modify the status of a patient within a cohort"}
 )
@@ -184,18 +276,19 @@ class newPatient(Resource):
 class updatePatient(Resource):
     # Add (include) patient, inverse of removePatient
     def put(self, cohort_id, patient_id):
-        """ (Re)-include patient """
+        """ (Re)-include patient with cohort"""
 
         res = conn.query(f"""MATCH (co:cohort{{CohortID:'{cohort_id}'}}) MATCH (px:patient{{PatientID:'{patient_id}'}}) MERGE (co)-[r:INCLUDE]-(px) RETURN r""")
         return ("Added {} patients from cohort".format(len(res)))
 
     # Remove (exclude) patient, inverse of addPatient
     def delete(self, cohort_id, patient_id):
-        """ Exclude patient """
+        """ Exclude patient from cohort"""
 
         res = conn.query(f"""MATCH (co:cohort{{CohortID:'{cohort_id}'}})-[r:INCLUDE]-(px:patient{{PatientID:'{patient_id}'}}) DELETE r RETURN r""")
         return ("Deleted {} patients from cohort".format(len(res)))
 
+
 if __name__ == '__main__':
-    app.run(host=os.environ['HOSTNAME'],port=5004, threaded=True, debug=False)
+    app.run(host=os.environ['HOSTNAME'],port=5004, threaded=True, debug=True)
 

--- a/data_processing/cohortManager/cohortManager.py
+++ b/data_processing/cohortManager/cohortManager.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, jsonify, render_template, make_response
+from flask_restx import Api, Resource
 from werkzeug.utils import secure_filename
 
 from data_processing.common.custom_logger import init_logger
@@ -14,9 +15,10 @@ import pandas as pd
 import threading
 
 app    = Flask(__name__)
+api = Api(app, version='1.1', title='cohortManager', description='Manages and exposes study cohort and associated data', ordered=True)
+
 logger = init_logger("flask-mind-server.log")
 cfg    = ConfigSet(name=const.APP_CFG,  config_file="config.yaml")
-spark  = SparkConfig().spark_session(const.APP_CFG, "data_processing.radiology.api.5004")
 conn   = Neo4jConnection(uri=os.environ["GRAPH_URI"], user="neo4j", pwd="password")
 lock   = threading.Lock()
 
@@ -31,88 +33,111 @@ HOST = os.environ['HOSTNAME']
 # ==================================================================================================
 
 # List all the patients
-@app.route('/mind/api/v1/listPatients/<cohort_id>', methods=['GET'])
-def listPatients(cohort_id):
+@api.route('/mind/api/v1/patient/list/<cohort_id>', 
+    methods=['GET'],
+    doc={"description": "List all the patients and recursively, their cases, scans, and available data"}
+)
+@api.doc(params={'cohort_id': 'Cohort Identifier'})
+class listPatients(Resource):
+    def get(self, cohort_id):
+        """ Retrieve patient listing """
 
-    # Matches (cohort <include> patients)
-    res = conn.query(f"""
-        MATCH (co:cohort{{CohortID:'{cohort_id}'}})-[:INCLUDE]-(px:patient) 
-        RETURN px
-        """
-    )
+        # Matches (cohort <include> patients)
+        res = conn.query(f"""
+            MATCH (co:cohort{{CohortID:'{cohort_id}'}})-[:INCLUDE]-(px:patient) 
+            RETURN px
+            """
+        )
 
-    all_px = []
-    for rec in res:
-        px_dict = rec.data()['px']
-        patient_id = px_dict['PatientID']
-        px_dict['cases'] = requests.get(f'http://{HOST}:5004/mind/api/v1/listCases/{cohort_id}/{patient_id}').json()
-        all_px.append(px_dict)
-    return jsonify(all_px)
+        all_px = []
+        for rec in res:
+            px_dict = rec.data()['px']
+            patient_id = px_dict['PatientID']
+            px_dict['cases'] = requests.get(f'http://{HOST}:5004/mind/api/v1/case/list/{cohort_id}/{patient_id}').json()
+            all_px.append(px_dict)
+        return jsonify(all_px)
 
 # List all the cases
-@app.route('/mind/api/v1/listCases/<cohort_id>/<patient_id>', methods=['GET'])
-def listCases(cohort_id, patient_id):
+@api.route('/mind/api/v1/case/list/<cohort_id>/<patient_id>', 
+    methods=['GET'],
+    doc={"description": "List all cases for a given patient and recursively their scans and available data"}
+)
+@api.doc(params={'cohort_id': 'Cohort Identifier', 'patient_id': 'Patient Identifier'})
+class listCases(Resource):
+    def get(self, cohort_id, patient_id):
+        """ Retrieve case listing """
 
-    # Matches (cohort <include> patients <has_case> cases)
-    res = conn.query(f"""
-        MATCH (co:cohort{{CohortID:'{cohort_id}'}})
-        -[:INCLUDE]-(px:patient{{PatientID:'{patient_id}'}})
-        -[:HAS_CASE]-(cases:accession) 
-        RETURN cases
-        """
-    )
+        # Matches (cohort <include> patients <has_case> cases)
+        res = conn.query(f"""
+            MATCH (co:cohort{{CohortID:'{cohort_id}'}})
+            -[:INCLUDE]-(px:patient{{PatientID:'{patient_id}'}})
+            -[:HAS_CASE]-(cases:accession) 
+            RETURN cases
+            """
+        )
 
-    all_case = []
-    for rec in res:
-        case_dict = rec.data()['cases']
-        accession_number   = case_dict['AccessionNumber']
-        case_dict['scans'] = requests.get(f'http://{HOST}:5004/mind/api/v1/listScans/{cohort_id}/{patient_id}/{accession_number}').json()
-        all_case.append(case_dict)
-    return jsonify(all_case)
+        all_case = []
+        for rec in res:
+            case_dict = rec.data()['cases']
+            accession_number   = case_dict['AccessionNumber']
+            case_dict['scans'] = requests.get(f'http://{HOST}:5004/mind/api/v1/scan/list/{cohort_id}/{patient_id}/{accession_number}').json()
+            all_case.append(case_dict)
+        return jsonify(all_case)
 
 # List all the scans
-@app.route('/mind/api/v1/listScans/<cohort_id>/<patient_id>/<accession_number>', methods=['GET'])
-def listScans(cohort_id, patient_id, accession_number):
-    
-    # Matches (cohort <include> patients <has_case> cases <has_scan> scan <include> cohort)
-    res = conn.query(f"""
-        MATCH (co:cohort{{CohortID:'{cohort_id}'}})
-        -[:INCLUDE]-(px:patient{{PatientID:'{patient_id}'}})
-        -[:HAS_CASE]-(cases:accession{{AccessionNumber:'{accession_number}'}})
-        -[:HAS_SCAN]-(sc:scan)
-        -[:INCLUDE]-(co)
-        RETURN sc, id(sc)
-        """
-    )
+@api.route('/mind/api/v1/scan/list/<cohort_id>/<patient_id>/<accession_number>', 
+    methods=['GET'],
+    doc={"description": "List all scans for a given case accession number and recursively their available data"}
+)
+@api.doc(params={'cohort_id': 'Cohort Identifier', 'patient_id': 'Patient Identifier', 'accession_number':'Case Accession Number'})
+class listScans(Resource):
+    def get (self, cohort_id, patient_id, accession_number):
+        """ Retrieve case listing """
 
-    all_scan = []
-    for rec in res:
-        scan_dict = rec.data()['sc']
-        scan_id   = rec.data()['id(sc)']
-        scan_dict['id']   = scan_id
-        scan_dict['data'] = requests.get(f'http://{HOST}:5004/mind/api/v1/listData/{scan_id}').json()
-        all_scan.append(scan_dict)
-    return jsonify(all_scan)
+        # Matches (cohort <include> patients <has_case> cases <has_scan> scan <include> cohort)
+        res = conn.query(f"""
+            MATCH (co:cohort{{CohortID:'{cohort_id}'}})
+            -[:INCLUDE]-(px:patient{{PatientID:'{patient_id}'}})
+            -[:HAS_CASE]-(cases:accession{{AccessionNumber:'{accession_number}'}})
+            -[:HAS_SCAN]-(sc:scan)
+            -[:INCLUDE]-(co)
+            RETURN sc, id(sc)
+            """
+        )
+
+        all_scan = []
+        for rec in res:
+            scan_dict = rec.data()['sc']
+            scan_id   = rec.data()['id(sc)']
+            scan_dict['id']   = scan_id
+            scan_dict['data'] = requests.get(f'http://{HOST}:5004/mind/api/v1/container/scan/{scan_id}').json()
+            all_scan.append(scan_dict)
+        return jsonify(all_scan)
 
 # List all the data
-@app.route('/mind/api/v1/listData/<id>', methods=['GET'])
-def listData(id):
+@api.route('/mind/api/v1/container/<container_type>/<container_id>', 
+    methods=['GET'],
+    doc={"description": "List all available data for a given a scan container"}
+)
+@api.doc(params={'container_type': 'Container type, e.g. scan, slide', 'container_id': 'Unique container identifier'})
+class listContainer(Resource):
+    def get (self, container_type, container_id):
+        """ Retrieve container data listing """
 
-    # Matches (scan <has_data> data)
-    res = conn.query(f"""
-        MATCH (sc:scan)-[:HAS_DATA]-(data) 
-        WHERE id(sc)={id} 
-        RETURN data, labels(data)
-        """
-    )
+        # Matches (scan <has_data> data)
+        res = conn.query(f"""
+            MATCH (sc:{container_type})-[:HAS_DATA]-(data) 
+            WHERE id(sc)={container_id} 
+            RETURN data, labels(data)
+            """
+        )
 
-    all_data = []
-    for rec in res:
-        data_dict = rec.data()['data']
-        data_dict['type'] = rec.data()['labels(data)'][0]
-        all_data.append(data_dict)
-    return jsonify(all_data)
-
+        all_data = []
+        for rec in res:
+            data_dict = rec.data()['data']
+            data_dict['type'] = rec.data()['labels(data)'][0]
+            all_data.append(data_dict)
+        return jsonify(all_data)
 
 
 # ==================================================================================================
@@ -120,96 +145,57 @@ def listData(id):
 # ==================================================================================================
 
 # Add a new (and include) patient with cases
-@app.route('/mind/api/v1/newPatient/<cohort_id>/<patient_id>/<case_list>', methods=['GET'])
-def newPatient(cohort_id, patient_id, case_list):
+@api.route('/mind/api/v1/patient/new/<cohort_id>/<patient_id>/<case_list>', 
+    methods=['POST'],
+    doc={"description": "Creates a new patient initalized with some cases"}
+)
+@api.doc(
+    params={'cohort_id': 'Cohort Identifier', 'patient_id': 'New patient identifier to create', 'case_list':'Comma seperated list of accession numbers to add'},
+    responses={200:"Success", 500:"Failed to add patient"}
+)
+class newPatient(Resource):
+    def post(self, cohort_id, patient_id, case_list):
+        """ Create new patient """
 
-    res = conn.query(f"""
-        MATCH (cases:accession) 
-        WHERE cases.AccessionNumber IN [{case_list}] 
-        MERGE (px:patient{{PatientID:'{patient_id}'}})
-        MERGE (co:cohort{{CohortID:'{cohort_id}'}})
-        MERGE (co)-[r1:INCLUDE]-(px)
-        MERGE (co)-[r2:INCLUDE]-(cases)
-        MERGE (px)-[r3:HAS_CASE]->(cases) 
-        RETURN cases
-        """
-    )
-    res = [rec.data()['cases'] for rec in res]
-    
-    return (f"Added {patient_id} to {cohort_id} with {len(res)} cases: {res}")
+        res = conn.query(f"""
+            MATCH (cases:accession) 
+            WHERE cases.AccessionNumber IN [{case_list}] 
+            MERGE (px:patient{{PatientID:'{patient_id}'}})
+            MERGE (co:cohort{{CohortID:'{cohort_id}'}})
+            MERGE (co)-[r1:INCLUDE]-(px)
+            MERGE (co)-[r2:INCLUDE]-(cases)
+            MERGE (px)-[r3:HAS_CASE]->(cases) 
+            RETURN cases
+            """
+        )
+        res = [rec.data()['cases'] for rec in res]
+        if len (res)==0: 
+            return make_response("No cases", 500)
+        else:
+            return make_response (f"Added {patient_id} to {cohort_id} with {len(res)} cases: {res}", 200)
 
-# Add (include) patient, inverse of removePatient
-@app.route('/mind/api/v1/addPatient/<cohort_id>/<patient_id>', methods=['GET'])
-def addPatient(cohort_id, patient_id):
-    res = conn.query(f"""MATCH (co:cohort{{CohortID:'{cohort_id}'}}) MATCH (px:patient{{PatientID:'{patient_id}'}}) MERGE (co)-[r:INCLUDE]-(px) RETURN r""")
-    return ("Added {} patients from cohort".format(len(res)))
+@api.route('/mind/api/v1/patient/<cohort_id>/<patient_id>', 
+    methods=['PUT', 'DELETE'],
+    doc={"description": "Modify the status of a patient within a cohort"}
+)
+@api.doc(
+    params={'cohort_id': 'Cohort Identifier', 'patient_id': 'Patient identifier to modify'}
+)
+class updatePatient(Resource):
+    # Add (include) patient, inverse of removePatient
+    def put(self, cohort_id, patient_id):
+        """ (Re)-include patient """
 
-# Remove (exclude) patient, inverse of addPatient
-@app.route('/mind/api/v1/removePatient/<cohort_id>/<patient_id>', methods=['GET'])
-def removePatient(cohort_id, patient_id):
-    res = conn.query(f"""MATCH (co:cohort{{CohortID:'{cohort_id}'}})-[r:INCLUDE]-(px:patient{{PatientID:'{patient_id}'}}) DELETE r RETURN r""")
-    return ("Deleted {} patients from cohort".format(len(res)))
+        res = conn.query(f"""MATCH (co:cohort{{CohortID:'{cohort_id}'}}) MATCH (px:patient{{PatientID:'{patient_id}'}}) MERGE (co)-[r:INCLUDE]-(px) RETURN r""")
+        return ("Added {} patients from cohort".format(len(res)))
 
+    # Remove (exclude) patient, inverse of addPatient
+    def delete(self, cohort_id, patient_id):
+        """ Exclude patient """
 
-
-# ==================================================================================================
-# Routes to extract scan data
-# ==================================================================================================
-# Initilize scans with DCM data
-@app.route('/mind/api/v1/initScans/<cohort_id>/<query>', methods=['GET'])
-def initScans(cohort_id, query):
-    # Get relevant patients and cases
-    res_tree = conn.query(f"""
-        MATCH (co:cohort{{CohortID:'{cohort_id}'}})-[:INCLUDE]-(cases:accession)-[*]->(das:dataset) WHERE das.DATA_TYPE="DCM" \
-        RETURN DISTINCT co, cases
-        """
-    )
-
-    # Get the "Parquet Dataset"
-    res_data = conn.query(f"""
-        MATCH (co:cohort{{CohortID:'{cohort_id}'}})-[:INCLUDE]-(cases:accession)-[*]->(das:dataset) WHERE das.DATA_TYPE="DCM" \
-        RETURN DISTINCT das
-        """
-    )
-
-    logger.info("Length of dataset = {}".format(len(res_data)))
-
-    cSchema = StructType([StructField("CohortID", StringType(), True), StructField("AccessionNumber", StringType(), True)])
-    df_cohort = spark.createDataFrame(([(x.data()['co']['CohortID'], x.data()['cases']['AccessionNumber']) for x in res_tree]),schema=cSchema)
-
-    if not len(res_data)==1: return make_response(("Operations only support singleton datasets right now", 500))
-
-    df = spark.read\
-        .format("delta")\
-        .load(res_data[0]['das']['TABLE_LOCATION'])\
-        .select("path", \
-            "AccessionNumber", \
-            "SeriesInstanceUID", \
-            "metadata.SeriesNumber", \
-            "metadata.SeriesDescription", \
-            "metadata.PerformedProcedureStepDescription", \
-            "metadata.ImageType", \
-            "metadata.InstanceNumber")\
-        .where(query)\
-        .where("InstanceNumber='1'")\
-        .orderBy("AccessionNumber") \
-        .join(df_cohort, ['AccessionNumber'])
-
-    for index, row in df.toPandas().iterrows():
-        prop_string = ",".join( ['''{0}:"{1}"'''.format(key, row[key]) for key in row.index] )
-        query = """
-                MATCH (co:cohort{{CohortID:'{2}'}})
-                MATCH (sc:scan{{SeriesInstanceUID:'{0}'}})
-                MERGE (data:dcm{{{1}}})
-                MERGE (sc)-[:HAS_DATA]-(data)
-                MERGE (co)-[:INCLUDE]-(sc) RETURN data
-                """.format(row['SeriesInstanceUID'], prop_string, cohort_id)
-        logger.info (query)
-        conn.query(query)
-
-    return make_response("Done", 200)
-
+        res = conn.query(f"""MATCH (co:cohort{{CohortID:'{cohort_id}'}})-[r:INCLUDE]-(px:patient{{PatientID:'{patient_id}'}}) DELETE r RETURN r""")
+        return ("Deleted {} patients from cohort".format(len(res)))
 
 if __name__ == '__main__':
-    app.run(host=os.environ['HOSTNAME'],port=5004, threaded=True, debug=True)
+    app.run(host=os.environ['HOSTNAME'],port=5004, threaded=True, debug=False)
 

--- a/data_processing/common/GraphEnum.py
+++ b/data_processing/common/GraphEnum.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 class Node(object):
 	"""
 	Node object defines the type and attributes of a graph node.
@@ -7,10 +8,48 @@ class Node(object):
 	:param: node_type: node type. e.g. scan
 	:param: fields: list of column names. e.g. slide_id
 	"""
-	def __init__(self, node_type, fields):
+	def __init__(self, node_type, fields=[], properties={}):
 
 		self.type = node_type
 		self.fields = fields
+		self.properties = properties
+
+		if self.type=="cohort":
+			if not "CohortID" in properties.keys():
+				raise RuntimeError("Cohorts must have a CohortID!")
+			self.properties["QualifiedPath"] = self.get_qualified_name(properties["CohortID"], properties["CohortID"])
+
+		if self.type=="patient":
+			if not "PatientID" in properties.keys() and "Namespace" in properties.keys():
+				raise RuntimeError("Patients must have a PatientID and Namespace property!")
+			self.properties["QualifiedPath"] = self.get_qualified_name(properties["Namespace"], properties["PatientID"])
+
+	def create(self):
+		prop_string = self.prop_str(self.properties.keys(), self.properties)
+		return f"""{self.type}:globals{{ {prop_string} }}"""
+
+	def match(self):
+		prop_string = self.prop_str( ["QualifiedPath"], self.properties)
+		return f"""{self.type}{{ {prop_string} }}"""
+
+	@staticmethod
+	def prop_str(fields, row):
+		"""
+		Returns a kv string like 'id: 123, ...' where prop values come from row.
+		"""
+		fields = set(fields).intersection(set(row.keys()))
+
+		kv = [f" {x}: '{row[x]}'" for x in fields]
+		return ','.join(kv)
+	
+	@staticmethod
+	def get_qualified_name(namespace, identifier): 
+		"""
+		Returns the full name given a namespace and patient ID
+		"""
+		return f"{namespace}::{identifier}"
+	
+
 
 class Graph(object):
 	"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ PyYAML==5.3.1
 jsonpath-ng==1.5.2
 yamale==3.0.4
 pydicom==2.1.0
+flask_restx

--- a/tests/data_processing/common/test_graph_enum.py
+++ b/tests/data_processing/common/test_graph_enum.py
@@ -16,7 +16,7 @@ def test_patient_create():
     assert "ExtraKey"   in create_string
 
 def test_patient_match():
-    match_string = Node("pvim atient", properties={"PatientID":"my_patient", "Namespace":"my_cohort"}).match()
+    match_string = Node("patient", properties={"PatientID":"my_patient", "Namespace":"my_cohort"}).match()
     assert "patient" in match_string    
     assert "QualifiedPath: 'my_cohort::my_patient'"   in match_string
     assert "ExtraKey"  not in match_string

--- a/tests/data_processing/common/test_graph_enum.py
+++ b/tests/data_processing/common/test_graph_enum.py
@@ -16,7 +16,7 @@ def test_patient_create():
     assert "ExtraKey"   in create_string
 
 def test_patient_match():
-    match_string = Node("patient", properties={"PatientID":"my_patient", "Namespace":"my_cohort"}).match()
+    match_string = Node("pvim atient", properties={"PatientID":"my_patient", "Namespace":"my_cohort"}).match()
     assert "patient" in match_string    
     assert "QualifiedPath: 'my_cohort::my_patient'"   in match_string
     assert "ExtraKey"  not in match_string
@@ -31,7 +31,6 @@ def test_cohort_create():
 
 def test_cohort_match():
     match_string = Node("cohort", properties={"CohortID":"my_cohort", "NewKey":"a cohort"}).match()
-    print (match_string)
     assert "cohort" in match_string    
     assert "QualifiedPath: 'my_cohort::my_cohort'"   in match_string
     assert "ExtraKey"  not in match_string

--- a/tests/data_processing/common/test_graph_enum.py
+++ b/tests/data_processing/common/test_graph_enum.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+'''
+Created on October 17, 2019
+
+@author: aukermaa@mskcc.org
+'''
+import pytest
+
+from data_processing.common.GraphEnum import Node
+
+def test_patient_create():
+    create_string = Node("patient", properties={"PatientID":"my_patient", "Namespace":"my_cohort", "ExtraKey":"a patient"}).create()
+    assert "patient:globals" in create_string    
+    assert "QualifiedPath: 'my_cohort::my_patient'"   in create_string
+    assert "PatientID"  in create_string
+    assert "ExtraKey"   in create_string
+
+def test_patient_match():
+    match_string = Node("patient", properties={"PatientID":"my_patient", "Namespace":"my_cohort"}).match()
+    assert "patient" in match_string    
+    assert "QualifiedPath: 'my_cohort::my_patient'"   in match_string
+    assert "ExtraKey"  not in match_string
+
+
+def test_cohort_create():
+    create_string = Node("cohort", properties={"CohortID":"my_cohort", "ExtraKey":"a cohort"}).create()
+    assert "cohort:globals" in create_string    
+    assert "QualifiedPath: 'my_cohort::my_cohort'"  in create_string
+    assert "CohortID"  in create_string
+    assert "ExtraKey"  in create_string
+
+def test_cohort_match():
+    match_string = Node("cohort", properties={"CohortID":"my_cohort", "NewKey":"a cohort"}).match()
+    print (match_string)
+    assert "cohort" in match_string    
+    assert "QualifiedPath: 'my_cohort::my_cohort'"   in match_string
+    assert "ExtraKey"  not in match_string


### PR DESCRIPTION
Major cleanup/refactoring:

1. Patients belong to a cohort namespace, with uniqueness requirement
2. Swagger documentation using restx at / (works with latest version of werkzeug), see it at "host":5004
3. Added convenience methods for working with patient and cohort nodes 
4. Added unit tests for patient and cohort node logic (match vs. create)
5. Simplified API routes
6. Error and response messages make sense and are informative (mostly)
