### PR TITLE
fixes for CircleCI reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -18,3 +18,6 @@ comment:
   layout: "reach,diff,flags,files,footer"
   behavior: default
   require_changes: no
+
+fixes:
+   - "/home/circleci/::"


### PR DESCRIPTION
Apparently we had to do this with the new code-cov release: https://docs.codecov.io/docs/fixing-paths