### PR TITLE
BR radiomics: generalize methods to run on accession containers 

### DIFF
--- a/data_processing/scanManager/extractRadiomics.py
+++ b/data_processing/scanManager/extractRadiomics.py
@@ -29,10 +29,10 @@ def get_container_data(container_id):
     conn = Neo4jConnection(uri=os.environ["GRAPH_URI"], user="neo4j", pwd="password")
 
     input_nodes = conn.query(f"""
-        MATCH (object)-[:HAS_DATA]-(image:mhd)
-        MATCH (object)-[:HAS_DATA]-(label:mha)
-        WHERE id(object)={container_id}
-        RETURN object.QualifiedPath, object.name, image.path, label.path"""
+        MATCH (container)-[:HAS_DATA]-(image:mhd)
+        MATCH (container)-[:HAS_DATA]-(label:mha)
+        WHERE id(container)={container_id}
+        RETURN container.QualifiedPath, container.name, image.path, label.path"""
     )
 
     if not input_nodes or len (input_nodes)==0:
@@ -50,9 +50,9 @@ def add_container_data(container_id, n_meta):
     conn = Neo4jConnection(uri=os.environ["GRAPH_URI"], user="neo4j", pwd="password")
 
     res = conn.query(f""" 
-        MATCH (object) WHERE id(object)={container_id}
+        MATCH (container) WHERE id(container)={container_id}
         MERGE (da:{n_meta.get_create_str()})
-        MERGE (object)-[:HAS_DATA]->(da)"""
+        MERGE (container)-[:HAS_DATA]->(da)"""
     )
 
 @click.command()
@@ -82,7 +82,7 @@ def cli(cohort_id, container_id, method_id):
 
     # Data just goes under namespace/name
     # TODO: This path is really not great, but works for now
-    output_dir = os.path.join(os.environ['MIND_GPFS_DIR'], "data/COHORTS", cohort_id, input_data['object.name'])
+    output_dir = os.path.join(os.environ['MIND_GPFS_DIR'], "data/COHORTS", cohort_id, input_data['container.name'])
 
     if not os.path.exists(output_dir): os.makedirs(output_dir)
 
@@ -102,7 +102,7 @@ def cli(cohort_id, container_id, method_id):
 
     add_container_data(container_id, n_meta)
 
-    logger.info ("Successfully extracted radiomics for container: " + input_data["object.QualifiedPath"])
+    logger.info ("Successfully extracted radiomics for container: " + input_data["container.QualifiedPath"])
 
 if __name__ == "__main__":
     cli()

--- a/tests/data_processing/scanManager/test_extractRadiomics.py
+++ b/tests/data_processing/scanManager/test_extractRadiomics.py
@@ -11,7 +11,7 @@ def test_cli_radiomics(mocker, monkeypatch):
     monkeypatch.setenv("MIND_GPFS_DIR", cwd+"/tests/data_mock/")
 
     # mock graph connection
-    mocker.patch("data_processing.scanManager.extractRadiomics.get_container_data", return_value={'object.QualifiedPath':'test-cohort::1.240.0.1', 'object.name': "1.240.0.1", 'image.path':f'file:{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/volumes/image.mhd', 'label.path':f'file:{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/volumes/label.mha'})
+    mocker.patch("data_processing.scanManager.extractRadiomics.get_container_data", return_value={'container.QualifiedPath':'test-cohort::1.240.0.1', 'container.name': "1.240.0.1", 'image.path':f'file:{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/volumes/image.mhd', 'label.path':f'file:{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/volumes/label.mha'})
     mocker.patch("data_processing.scanManager.extractRadiomics.get_method_data", return_value={'interpolator': 'sitkBSpline', 'resampledPixelSpacing': [1, 1, 1], 'padDistance': 10, 'voxelArrayShift': 1000, 'binWidth': 25, 'verbose': 'True', 'label': 1, 'geometryTolerance': 0.0001})
 
     mock_db = mocker.patch("data_processing.scanManager.extractRadiomics.add_container_data", return_value=None)
@@ -29,7 +29,7 @@ def test_cli_radiomics_params(mocker, monkeypatch):
     monkeypatch.setenv("MIND_GPFS_DIR", cwd+"/tests/data_mock/")
 
     # mock graph connection
-    mocker.patch("data_processing.scanManager.extractRadiomics.get_container_data", return_value={'object.QualifiedPath':'test-cohort::1.240.0.2','object.name': "1.240.0.2", 'image.path':f'file:{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/volumes/image.mhd', 'label.path':f'file:{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/volumes/label.mha'})
+    mocker.patch("data_processing.scanManager.extractRadiomics.get_container_data", return_value={'container.QualifiedPath':'test-cohort::1.240.0.2','container.name': "1.240.0.2", 'image.path':f'file:{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/volumes/image.mhd', 'label.path':f'file:{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/volumes/label.mha'})
     mocker.patch("data_processing.scanManager.extractRadiomics.get_method_data", return_value={'interpolator': 'sitkBSpline', 'resampledPixelSpacing': [1, 1, 1], 'padDistance': 10, 'voxelArrayShift': 1000, 'binWidth': 50, 'verbose': 'True', 'label': 1, 'geometryTolerance': 0.0001})
 
     mock_db = mocker.patch("data_processing.scanManager.extractRadiomics.add_container_data", return_value=None)

--- a/tests/data_processing/scanManager/test_extractRadiomics.py
+++ b/tests/data_processing/scanManager/test_extractRadiomics.py
@@ -11,7 +11,7 @@ def test_cli_radiomics(mocker, monkeypatch):
     monkeypatch.setenv("MIND_GPFS_DIR", cwd+"/tests/data_mock/")
 
     # mock graph connection
-    mocker.patch("data_processing.scanManager.extractRadiomics.get_container_data", return_value={'object.SeriesInstanceUID': "1.240.0.1", 'image.path':f'file:{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/volumes/image.mhd', 'label.path':f'file:{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/volumes/label.mha'})
+    mocker.patch("data_processing.scanManager.extractRadiomics.get_container_data", return_value={'object.QualifiedPath':'test-cohort::1.240.0.1', 'object.name': "1.240.0.1", 'image.path':f'file:{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/volumes/image.mhd', 'label.path':f'file:{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/volumes/label.mha'})
     mocker.patch("data_processing.scanManager.extractRadiomics.get_method_data", return_value={'interpolator': 'sitkBSpline', 'resampledPixelSpacing': [1, 1, 1], 'padDistance': 10, 'voxelArrayShift': 1000, 'binWidth': 25, 'verbose': 'True', 'label': 1, 'geometryTolerance': 0.0001})
 
     mock_db = mocker.patch("data_processing.scanManager.extractRadiomics.add_container_data", return_value=None)
@@ -29,7 +29,7 @@ def test_cli_radiomics_params(mocker, monkeypatch):
     monkeypatch.setenv("MIND_GPFS_DIR", cwd+"/tests/data_mock/")
 
     # mock graph connection
-    mocker.patch("data_processing.scanManager.extractRadiomics.get_container_data", return_value={'object.SeriesInstanceUID': "1.240.0.2", 'image.path':f'file:{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/volumes/image.mhd', 'label.path':f'file:{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/volumes/label.mha'})
+    mocker.patch("data_processing.scanManager.extractRadiomics.get_container_data", return_value={'object.QualifiedPath':'test-cohort::1.240.0.2','object.name': "1.240.0.2", 'image.path':f'file:{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/volumes/image.mhd', 'label.path':f'file:{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/volumes/label.mha'})
     mocker.patch("data_processing.scanManager.extractRadiomics.get_method_data", return_value={'interpolator': 'sitkBSpline', 'resampledPixelSpacing': [1, 1, 1], 'padDistance': 10, 'voxelArrayShift': 1000, 'binWidth': 50, 'verbose': 'True', 'label': 1, 'geometryTolerance': 0.0001})
 
     mock_db = mocker.patch("data_processing.scanManager.extractRadiomics.add_container_data", return_value=None)


### PR DESCRIPTION
For the breast project, images and labels were added to accessions, not scans.  

- Generalize radiomics code to operate on accession nodes as containers. 
- Overload to run on a single container with `/mind/api/v1/methods/{cohort_id}/{method_id}/{container_id}/run`
- Includes import fix for Node.

