### PR TITLE
Radiology processing job endpoints

### DIFF
--- a/config.yaml.template
+++ b/config.yaml.template
@@ -41,6 +41,7 @@ GRAPH_URI: neo4j://localhost:7687
 GRAPH_USER: user
 GRAPH_PASSWORD: password
 
+OBJECT_STORE_ENABLED: True
 MINIO_URI: localhost:8000
 MINIO_USER: user
 MINIO_PASSWORD: password

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -26,3 +26,21 @@ spark_application_config:
   - spark.sql.shuffle.partitions: 300
 
   - spark.driver.maxResultSize: 2g
+
+scanManager_port: 5001 
+getPathologyAnnotations_port: 5002 
+scanManager_port: 5003 
+cohortManager_port: 5004 
+radiologyPreprocessingLibrary_port: 5005
+radiology_service_port: 5006 
+
+scanManager_processes: 16 
+radiology_service_processes: 16 
+
+GRAPH_URI: neo4j://localhost:7687
+GRAPH_USER: user
+GRAPH_PASSWORD: password
+
+MINIO_URI: localhost:8000
+MINIO_USER: user
+MINIO_PASSWORD: password

--- a/data_processing/common/Container.py
+++ b/data_processing/common/Container.py
@@ -80,7 +80,7 @@ class Container(object):
         # Connect to graph DB
         self.logger.info ("Connecting to: %s", params['GRAPH_URI'])
         self._conn = Neo4jConnection(uri=params['GRAPH_URI'], user=params['GRAPH_USER'], pwd=params['GRAPH_PASSWORD'])
-        self.logger.info ("Connection test to %s: %s", params['GRAPH_URI'], self._conn.test_connection())
+        self.logger.info ("Connection test: %s", self._conn.test_connection())
 
         self.logger.info ("Connecting to: %s", params['MINIO_URI'])
         self._client = Minio(params['MINIO_URI'], access_key=params['MINIO_USER'], secret_key=params['MINIO_PASSWORD'], secure=False)

--- a/data_processing/common/Container.py
+++ b/data_processing/common/Container.py
@@ -1,8 +1,11 @@
 from data_processing.common.Neo4jConnection import Neo4jConnection
 from data_processing.common.Node import Node
+from data_processing.common.config import ConfigSet
 
 import os, socket, pathlib, logging
+from minio import Minio
 
+from concurrent.futures import ThreadPoolExecutor
 
 class Container(object):
     """
@@ -71,14 +74,29 @@ class Container(object):
         #self.logger = init_logger("common-container.log", "Container [empty]")
         self.logger = logging.getLogger(__name__)
 
-        self.params=params
+        if isinstance(params, ConfigSet):
+            params=params.get_config_set("CONTAINER_CFG")
 
         # Connect to graph DB
         self.logger.info ("Connecting to: %s", params['GRAPH_URI'])
         self._conn = Neo4jConnection(uri=params['GRAPH_URI'], user=params['GRAPH_USER'], pwd=params['GRAPH_PASSWORD'])
-        self.logger.info ("Connection test: %s", self._conn.test_connection())
+        self.logger.info ("Connection test to %s: %s", params['GRAPH_URI'], self._conn.test_connection())
+
+        self.logger.info ("Connecting to: %s", params['MINIO_URI'])
+        self._client = Minio(params['MINIO_URI'], access_key=params['MINIO_USER'], secret_key=params['MINIO_PASSWORD'], secure=False)
+        try:
+            for bucket in self._client.list_buckets():
+                self.logger.info("Found bucket %s", bucket.name )
+            self.logger.info("object_store_enabled=True")
+            params['object_store_enabled'] = True
+        except:
+            self.logger.warning("object_store_enabled=False")
+            params['object_store_enabled'] = False
+
         self._host = socket.gethostname() # portable to *docker* containers
         self.logger.info ("Running on: %s", self._host)
+
+        self.params = params
     
     def setNamespace(self, namespace_id: str):
         """
@@ -86,8 +104,11 @@ class Container(object):
 
         :params: namespace_id - namespace value 
         """
-        self._namespace_id = namespace_id
+        self._namespace_id = namespace_id.lower()
         self.logger.info ("Container namespace: %s", self._namespace_id)
+
+        if not self._client.bucket_exists(self._namespace_id):
+            self._client.make_bucket(self._namespace_id)
 
         return self
     
@@ -280,7 +301,15 @@ class Container(object):
         
         # Decorate with the container namespace 
         self._node_commits[node.name].set_namespace( self._namespace_id, self._name )
-        self.logger.info ("Container has %s pending commits",  len(self._node_commits))
+        self.logger.info ("Container has %s pending node commits",  len(self._node_commits))
+
+        # Set node objects only if there is a path and the object store is enabled
+        if "path" in node.properties.keys() and self.params.get("object_store_enabled", False):
+            node.objects = []
+            node.properties['object_bucket'] = f"{self._namespace_id}"
+            node.properties['object_folder'] = f"{self._name}/{node.name}"
+            for path in pathlib.Path(node.properties['path']).glob("*"): node.objects.append(path)        
+            self.logger.info ("Node has %s pending object commits",  len(node.objects))
 
     def saveAll(self):
         """
@@ -298,3 +327,14 @@ class Container(object):
                     ON CREATE SET da = {n.get_map_str()}
                 """
             )
+
+            if self.params.get("object_store_enabled", False):
+                object_bucket = n.properties.get("object_bucket")
+                object_folder = n.properties.get("object_folder")
+
+                self.logger.info("Started object upload with 4 threads...")
+                with ThreadPoolExecutor(max_workers=4) as executor:
+                    for p in n.objects:
+                        self.logger.info("uploading: %s", f"minio/{object_bucket}/{object_folder}/{p.name}")
+                        executor.submit(self._client.fput_object, object_bucket, f"{object_folder}/{p.name}", p)
+            self.logger.info("Done.")

--- a/data_processing/common/config.py
+++ b/data_processing/common/config.py
@@ -195,6 +195,19 @@ class ConfigSet():
             raise ValueError('configuration with logical name '+name+' was never loaded')
 
         return list(ConfigSet.__INSTANCE.__config[name].keys())
+    
+    def get_config_set(self, name):
+        '''
+
+        :param name: logical name of the configuration
+        :return: a dictonary of top-level keys in the config stored in this instance.
+        :raises: ValueError if a configuration with the specified name was never loaded
+
+        '''
+        if ConfigSet.__INSTANCE is None or name not in ConfigSet.__INSTANCE.__config.keys():
+            raise ValueError('configuration with logical name '+name+' was never loaded')
+        return ConfigSet.__INSTANCE.__config[name]
+  
 
 
     def clear(self):

--- a/data_processing/radiology/common/preprocess.py
+++ b/data_processing/radiology/common/preprocess.py
@@ -266,7 +266,7 @@ def generate_scan(dicom_path: str, output_dir: str, params: dict) -> dict:
 
         writer = itk.ImageFileWriter[ImageType].New()
 
-        outFileName = os.path.join(output_dir, uid + '.' + params['file_ext'])
+        outFileName = os.path.join(output_dir, 'volumetric_image.' + params['itkImageType'])
         writer.SetFileName(outFileName)
         writer.UseCompressionOn()
         writer.SetInput(reader.GetOutput())
@@ -333,8 +333,8 @@ def window_dicoms(dicom_paths: list, output_dir: str, params: dict) -> dict:
     :param output_dir: destination directory
     :param params {
         window bool: whether to apply windowing
-        window.low_level int, float : lower level to clip
-        window.high_level int, float: higher level to clip
+        window_low_level  int, float : lower level to clip
+        window_high_level int, float: higher level to clip
     }
 
     :return: property dict, None if function fails
@@ -345,12 +345,12 @@ def window_dicoms(dicom_paths: list, output_dir: str, params: dict) -> dict:
     # Scale and clip each dicom, and save in new directory
     logger.info("Processing %s dicoms!", len(dicom_paths))
     if params.get('window', False):
-        logger.info ("Applying window [%s,%s]", params['window.low_level'], params['window.high_level'])
+        logger.info ("Applying window [%s,%s]", params['window_low_level'], params['window_high_level'])
     for dcm in dicom_paths:
         ds = dcmread(dcm)
         hu = ds.RescaleSlope * ds.pixel_array + ds.RescaleIntercept
         if params['window']:
-            hu = np.clip( hu, params['window.low_level'], params['window.high_level']   )
+            hu = np.clip( hu, params['window_low_level'], params['window_high_level']   )
         ds.PixelData = hu.astype(ds.pixel_array.dtype).tobytes()
         ds.save_as (os.path.join( output_dir, dcm.stem + ".cthu.dcm"  ))
 
@@ -358,9 +358,9 @@ def window_dicoms(dicom_paths: list, output_dir: str, params: dict) -> dict:
     properties = {
         "RescaleSlope": float(ds.RescaleSlope), 
         "RescaleIntercept": float(ds.RescaleIntercept), 
-        "units":"HU", 
-        "path":output_dir, 
-        "hash":dirhash(output_dir, "sha256")
+        "units": "HU", 
+        "path": output_dir, 
+        "hash": dirhash(output_dir, "sha256")
     }
 
     return properties

--- a/data_processing/scanManager/extractRadiomics.py
+++ b/data_processing/scanManager/extractRadiomics.py
@@ -18,11 +18,13 @@ from data_processing.common.custom_logger   import init_logger
 from data_processing.common.utils           import get_method_data
 from data_processing.common.Container       import Container
 from data_processing.common.Node            import Node
+from data_processing.common.config import ConfigSet
 
 # From radiology.common
 from data_processing.radiology.common.preprocess   import extract_radiomics
 
 logger = init_logger("extractRadiomics.log")
+cfg = ConfigSet("CONTAINER_CFG",  config_file="config.yaml")
 
 @click.command()
 @click.option('-c', '--cohort_id',    required=True)
@@ -33,15 +35,9 @@ def cli(cohort_id, container_id, method_id):
     extract_radiomics_with_container(cohort_id, container_id, method_data)
 
 def extract_radiomics_with_container(cohort_id, container_id, method_data):
-    # Eventually these will come from a cfg file, or somewhere else
-    container_params = {
-        'GRAPH_URI':  os.environ['GRAPH_URI'],
-        'GRAPH_USER': "neo4j",
-        'GRAPH_PASSWORD': "password"
-    }
 
     # Do some setup
-    container   = Container( container_params ).setNamespace(cohort_id).lookupAndAttach(container_id)
+    container   = Container( cfg ).setNamespace(cohort_id).lookupAndAttach(container_id)
     method_id   = method_data.get("job_tag", "none")
 
     image_node  = container.get("mhd", method_data['image_input_name']) 

--- a/data_processing/scanManager/extractRadiomics.py
+++ b/data_processing/scanManager/extractRadiomics.py
@@ -29,9 +29,10 @@ logger = init_logger("extractRadiomics.log")
 @click.option('-s', '--container_id', required=True)
 @click.option('-m', '--method_id',    required=True)
 def cli(cohort_id, container_id, method_id):
-    extract_radiomics_with_container(cohort_id, container_id, method_id)
+    method_data = get_method_data(cohort_id, method_id)
+    extract_radiomics_with_container(cohort_id, container_id, method_data)
 
-def extract_radiomics_with_container(cohort_id, container_id, method_id):
+def extract_radiomics_with_container(cohort_id, container_id, method_data):
     # Eventually these will come from a cfg file, or somewhere else
     container_params = {
         'GRAPH_URI':  os.environ['GRAPH_URI'],
@@ -41,7 +42,7 @@ def extract_radiomics_with_container(cohort_id, container_id, method_id):
 
     # Do some setup
     container   = Container( container_params ).setNamespace(cohort_id).lookupAndAttach(container_id)
-    method_data = get_method_data(cohort_id, method_id) 
+    method_id   = method_data.get("job_tag", "none")
 
     image_node  = container.get("mhd", method_data['image_input_name']) 
     label_node  = container.get("mha", method_data['label_input_name'])

--- a/data_processing/scanManager/extractRadiomics.py
+++ b/data_processing/scanManager/extractRadiomics.py
@@ -40,8 +40,8 @@ def extract_radiomics_with_container(cohort_id, container_id, method_data):
     container   = Container( cfg ).setNamespace(cohort_id).lookupAndAttach(container_id)
     method_id   = method_data.get("job_tag", "none")
 
-    image_node  = container.get("mhd", method_data['image_input_name']) 
-    label_node  = container.get("mha", method_data['label_input_name'])
+    image_node  = container.get("mhd", method_data['image_input_tag']) 
+    label_node  = container.get("mha", method_data['label_input_tag'])
 
     if image_node is None or label_node is None:
         logger.error("Image or Label not found, exiting!")

--- a/data_processing/scanManager/generateScan.py
+++ b/data_processing/scanManager/generateScan.py
@@ -40,7 +40,7 @@ def generate_scan_with_container(cohort_id, container_id, method_data):
     container   = Container( cfg ).setNamespace(cohort_id).lookupAndAttach(container_id)
     method_id   = method_data.get("job_tag", "none")
     
-    input_node  = container.get("dicom", method_data['input_name']) # Only get origional dicoms from
+    input_node  = container.get("dicom", method_data['dicom_input_tag']) # Only get origional dicoms from
 
     output_dir = os.path.join(os.environ['MIND_GPFS_DIR'], "data", container._namespace_id, container._name, method_id)
     if not os.path.exists(output_dir): os.makedirs(output_dir)
@@ -53,7 +53,7 @@ def generate_scan_with_container(cohort_id, container_id, method_data):
     
     if properties is None: return
 
-    output_node = Node(method_data['file_ext'], method_id, properties)
+    output_node = Node(method_data['itkImageType'], method_id, properties)
 
     container.add(output_node)
     container.saveAll()

--- a/data_processing/scanManager/generateScan.py
+++ b/data_processing/scanManager/generateScan.py
@@ -18,11 +18,13 @@ from data_processing.common.custom_logger   import init_logger
 from data_processing.common.utils           import get_method_data
 from data_processing.common.Container       import Container
 from data_processing.common.Node            import Node
+from data_processing.common.config import ConfigSet
 
 # From radiology.common
 from data_processing.radiology.common.preprocess import generate_scan
 
 logger = init_logger("generateScan.log")
+cfg = ConfigSet("CONTAINER_CFG",  config_file="config.yaml")
 
 @click.command()
 @click.option('-c', '--cohort_id',    required=True)
@@ -34,15 +36,8 @@ def cli(cohort_id, container_id, method_id):
 
 def generate_scan_with_container(cohort_id, container_id, method_data):
 
-    # Eventually these will come from a cfg file, or somewhere else
-    container_params = {
-        'GRAPH_URI':  os.environ['GRAPH_URI'],
-        'GRAPH_USER': "neo4j",
-        'GRAPH_PASSWORD': "password"
-    }
-
     # Do some setup
-    container   = Container( container_params ).setNamespace(cohort_id).lookupAndAttach(container_id)
+    container   = Container( cfg ).setNamespace(cohort_id).lookupAndAttach(container_id)
     method_id   = method_data.get("job_tag", "none")
     
     input_node  = container.get("dicom", method_data['input_name']) # Only get origional dicoms from

--- a/data_processing/scanManager/generateScan.py
+++ b/data_processing/scanManager/generateScan.py
@@ -29,9 +29,10 @@ logger = init_logger("generateScan.log")
 @click.option('-s', '--container_id', required=True)
 @click.option('-m', '--method_id',    required=True)
 def cli(cohort_id, container_id, method_id):
-    generate_scan_with_container(cohort_id, container_id, method_id)
+    method_data = get_method_data(cohort_id, method_id)
+    generate_scan_with_container(cohort_id, container_id, method_data)
 
-def generate_scan_with_container(cohort_id, container_id, method_id):
+def generate_scan_with_container(cohort_id, container_id, method_data):
 
     # Eventually these will come from a cfg file, or somewhere else
     container_params = {
@@ -42,7 +43,7 @@ def generate_scan_with_container(cohort_id, container_id, method_id):
 
     # Do some setup
     container   = Container( container_params ).setNamespace(cohort_id).lookupAndAttach(container_id)
-    method_data = get_method_data(cohort_id, method_id) 
+    method_id   = method_data.get("job_tag", "none")
     
     input_node  = container.get("dicom", method_data['input_name']) # Only get origional dicoms from
 

--- a/data_processing/scanManager/windowDicoms.py
+++ b/data_processing/scanManager/windowDicoms.py
@@ -29,9 +29,10 @@ logger = init_logger("windowDicoms.log")
 @click.option('-s', '--container_id', required=True)
 @click.option('-m', '--method_id',    required=True)
 def cli(cohort_id, container_id, method_id):
-    window_dicom_with_container(cohort_id, container_id, method_id)
+    method_data = get_method_data(cohort_id, method_id)
+    window_dicom_with_container(cohort_id, container_id, method_data)
 
-def window_dicom_with_container(cohort_id, container_id, method_id):
+def window_dicom_with_container(cohort_id, container_id, method_data):
     # Eventually these will come from a cfg file, or somewhere else
     container_params = {
         'GRAPH_URI':  os.environ['GRAPH_URI'],
@@ -41,7 +42,7 @@ def window_dicom_with_container(cohort_id, container_id, method_id):
 
     # Do some setup
     container   = Container( container_params ).setNamespace(cohort_id).lookupAndAttach(container_id)
-    method_data = get_method_data(cohort_id, method_id) 
+    method_id   = method_data.get("job_tag", "none")
 
     input_node  = container.get("dicom", method_data['input_name']) # Only get origional dicoms from
     

--- a/data_processing/scanManager/windowDicoms.py
+++ b/data_processing/scanManager/windowDicoms.py
@@ -40,7 +40,7 @@ def window_dicom_with_container(cohort_id, container_id, method_data):
     container   = Container( cfg ).setNamespace(cohort_id).lookupAndAttach(container_id)
     method_id   = method_data.get("job_tag", "none")
 
-    input_node  = container.get("dicom", method_data['input_name']) # Only get origional dicoms from
+    input_node  = container.get("dicom", method_data['dicom_input_tag']) # Only get origional dicoms from
     
     # Currently, store things at MIND_GPFS_DIR/data/<namespace>/<container name>/<method>/<schema>
     # Such that for every namespace, container, and method, there is one allocated path location

--- a/data_processing/scanManager/windowDicoms.py
+++ b/data_processing/scanManager/windowDicoms.py
@@ -18,11 +18,13 @@ from data_processing.common.custom_logger   import init_logger
 from data_processing.common.utils           import get_method_data
 from data_processing.common.Container       import Container
 from data_processing.common.Node            import Node
+from data_processing.common.config import ConfigSet
 
 # From radiology.common
 from data_processing.radiology.common.preprocess import window_dicoms
 
 logger = init_logger("windowDicoms.log")
+cfg = ConfigSet("CONTAINER_CFG",  config_file="config.yaml")
 
 @click.command()
 @click.option('-c', '--cohort_id',    required=True)
@@ -33,15 +35,9 @@ def cli(cohort_id, container_id, method_id):
     window_dicom_with_container(cohort_id, container_id, method_data)
 
 def window_dicom_with_container(cohort_id, container_id, method_data):
-    # Eventually these will come from a cfg file, or somewhere else
-    container_params = {
-        'GRAPH_URI':  os.environ['GRAPH_URI'],
-        'GRAPH_USER': "neo4j",
-        'GRAPH_PASSWORD': "password"
-    }
 
     # Do some setup
-    container   = Container( container_params ).setNamespace(cohort_id).lookupAndAttach(container_id)
+    container   = Container( cfg ).setNamespace(cohort_id).lookupAndAttach(container_id)
     method_id   = method_data.get("job_tag", "none")
 
     input_node  = container.get("dicom", method_data['input_name']) # Only get origional dicoms from

--- a/data_processing/services/radiology_service.py
+++ b/data_processing/services/radiology_service.py
@@ -83,7 +83,7 @@ generate_scan_model = api.model("Generate Volumetric Image",
 class API_window_dicom(Resource):
     @api.expect(window_dicom_model, validate=True)
     def post(self, cohort_id, container_id):
-        """Submit a scale and window CT dicom Job"""
+        """Submit a scale and window CT dicom job"""
         job_id = str(uuid.uuid4())
         future = executor.submit (window_dicom_with_container, cohort_id, container_id, request.json)
         return make_response( {"message": f"Submitted job {job_id} with future {future}", "job_id": job_id }, 202 )
@@ -92,7 +92,7 @@ class API_window_dicom(Resource):
 class API_extract_voxels(Resource):
     @api.expect(extract_voxels_model, validate=True)
     def post(self, cohort_id, container_id):
-        """Submit an extract radiomics Job"""
+        """Submit an volumentric resample and voxel extraction job"""
         job_id = str(uuid.uuid4())
         return make_response( "Not implimented yet", 400 )
         #future = executor.submit (extract_voxels_with_container, cohort_id, container_id, request.json)
@@ -102,7 +102,7 @@ class API_extract_voxels(Resource):
 class API_extract_radiomics(Resource):
     @api.expect(extract_radiomics_model, validate=True)
     def post(self, cohort_id, container_id):
-        """Submit an extract radiomics Job"""
+        """Submit an extract radiomics job"""
         job_id = str(uuid.uuid4())
         future = executor.submit (extract_radiomics_with_container, cohort_id, container_id, request.json)
         return make_response( {"message": f"Submitted job {job_id} with future {future}", "job_id": job_id }, 202 )
@@ -111,7 +111,7 @@ class API_extract_radiomics(Resource):
 class API_generate_scan(Resource):
     @api.expect(generate_scan_model, validate=True)
     def post(self, cohort_id, container_id):
-        """Submit a generate scan Job"""
+        """Submit a generate scan job"""
         job_id = str(uuid.uuid4())
         future = executor.submit (generate_scan_with_container, cohort_id, container_id, request.json)
         return make_response( {"message": f"Submitted job {job_id} with future {future}", "job_id": job_id }, 202 )

--- a/data_processing/services/radiology_service.py
+++ b/data_processing/services/radiology_service.py
@@ -23,6 +23,7 @@ from data_processing.common.custom_logger   import init_logger
 
 from data_processing.scanManager.windowDicoms       import window_dicom_with_container
 from data_processing.scanManager.extractRadiomics   import extract_radiomics_with_container
+# from data_processing.scanManager.extractVoxels   import extract_voxels_with_container
 from data_processing.scanManager.generateScan       import generate_scan_with_container
 
 logger = init_logger("radiology-service.log")
@@ -36,6 +37,16 @@ NUM_PROCS    = int(cfg.get_value("APP_CFG::radiology_service_processes"))
 app = Flask(__name__)
 api = Api(app, version=VERSION, title='MIND Radiology Processing Service', description='Job-style endpoints for radiology image processing', ordered=True)
 executor = ProcessPoolExecutor(NUM_PROCS) 
+
+# param models
+extract_voxels_model = api.model("Resample and Extract Voxels", 
+    {
+        "job_tag": fields.String(description="Tag/name of output record", required=True, example='my_radiomics'),
+        "image_input_name": fields.String(description="Tag/name of input image record", required=True, example='generated_mhd'),
+        "label_input_name": fields.String(description="Tag/name of label image record", required=True, example='user_segmentations'),
+        "resampledPixelSpacing": fields.List(fields.Float, description="Pixel resampling in mm in x,y,z", required=True, example=[1,1,1]),
+    }
+)
 
 # param models
 extract_radiomics_model = api.model("Extract Radiomics", 
@@ -76,6 +87,16 @@ class API_window_dicom(Resource):
         job_id = str(uuid.uuid4())
         future = executor.submit (window_dicom_with_container, cohort_id, container_id, request.json)
         return f"Submitted job {job_id} with future {future}"
+
+@api.route('/mind/api/v1/extract_voxels/<cohort_id>/<container_id>/submit', methods=['POST'])
+class API_extract_voxels(Resource):
+    @api.expect(extract_voxels_model, validate=True)
+    def post(self, cohort_id, container_id):
+        """Submit an extract radiomics Job"""
+        job_id = str(uuid.uuid4())
+        return "Not implimented yet"
+        #future = executor.submit (extract_voxels_with_container, cohort_id, container_id, request.json)
+        #return f"Submitted job {job_id} with future {future}"
 
 @api.route('/mind/api/v1/extract_radiomics/<cohort_id>/<container_id>/submit', methods=['POST'])
 class API_extract_radiomics(Resource):

--- a/data_processing/services/radiology_service.py
+++ b/data_processing/services/radiology_service.py
@@ -99,7 +99,12 @@ class API_generate_scan(Resource):
 @api.route('/service/health', methods=['GET'])
 class API_heatlh(Resource):
     def get(self):
-        return make_response("I'm doing okay! :)")
+        try:
+            executor.submit(print, "Test")
+            return make_response("I'm doing okay! :)")
+        except:
+            return make_response("I'm not okay :(", 400)
+        
 
 if __name__ == '__main__':
     # Setup App/Api

--- a/data_processing/services/radiology_service.py
+++ b/data_processing/services/radiology_service.py
@@ -86,7 +86,7 @@ class API_window_dicom(Resource):
         """Submit a scale and window CT dicom Job"""
         job_id = str(uuid.uuid4())
         future = executor.submit (window_dicom_with_container, cohort_id, container_id, request.json)
-        return f"Submitted job {job_id} with future {future}"
+        return make_response( f"Submitted job {job_id} with future {future}", 202)
 
 @api.route('/mind/api/v1/extract_voxels/<cohort_id>/<container_id>/submit', methods=['POST'])
 class API_extract_voxels(Resource):
@@ -94,9 +94,9 @@ class API_extract_voxels(Resource):
     def post(self, cohort_id, container_id):
         """Submit an extract radiomics Job"""
         job_id = str(uuid.uuid4())
-        return "Not implimented yet"
+        return make_response( "Not implimented yet", 402 )
         #future = executor.submit (extract_voxels_with_container, cohort_id, container_id, request.json)
-        #return f"Submitted job {job_id} with future {future}"
+        #return make_response( f"Submitted job {job_id} with future {future}"
 
 @api.route('/mind/api/v1/extract_radiomics/<cohort_id>/<container_id>/submit', methods=['POST'])
 class API_extract_radiomics(Resource):
@@ -105,7 +105,7 @@ class API_extract_radiomics(Resource):
         """Submit an extract radiomics Job"""
         job_id = str(uuid.uuid4())
         future = executor.submit (extract_radiomics_with_container, cohort_id, container_id, request.json)
-        return f"Submitted job {job_id} with future {future}"
+        return make_response( f"Submitted job {job_id} with future {future}", 202 )
 
 @api.route('/mind/api/v1/generate_scan/<cohort_id>/<container_id>/submit', methods=['POST'])
 class API_generate_scan(Resource):
@@ -114,7 +114,7 @@ class API_generate_scan(Resource):
         """Submit a generate scan Job"""
         job_id = str(uuid.uuid4())
         future = executor.submit (generate_scan_with_container, cohort_id, container_id, request.json)
-        return f"Submitted job {job_id} with future {future}"
+        return make_response( f"Submitted job {job_id} with future {future}", 202 )
 
 
 @api.route('/service/health', methods=['GET'])

--- a/data_processing/services/radiology_service.py
+++ b/data_processing/services/radiology_service.py
@@ -72,7 +72,7 @@ generate_scan_model = api.model("Generate Volumetric Image",
 class API_window_dicom(Resource):
     @api.expect(window_dicom_model, validate=True)
     def post(self, cohort_id, container_id):
-        """Submit job"""
+        """Submit a scale and window CT dicom Job"""
         job_id = str(uuid.uuid4())
         future = executor.submit (window_dicom_with_container, cohort_id, container_id, request.json)
         return f"Submitted job {job_id} with future {future}"
@@ -81,7 +81,7 @@ class API_window_dicom(Resource):
 class API_extract_radiomics(Resource):
     @api.expect(extract_radiomics_model, validate=True)
     def post(self, cohort_id, container_id):
-        """Submit job"""
+        """Submit an extract radiomics Job"""
         job_id = str(uuid.uuid4())
         future = executor.submit (extract_radiomics_with_container, cohort_id, container_id, request.json)
         return f"Submitted job {job_id} with future {future}"
@@ -90,7 +90,7 @@ class API_extract_radiomics(Resource):
 class API_generate_scan(Resource):
     @api.expect(generate_scan_model, validate=True)
     def post(self, cohort_id, container_id):
-        """Submit job"""
+        """Submit a generate scan Job"""
         job_id = str(uuid.uuid4())
         future = executor.submit (generate_scan_with_container, cohort_id, container_id, request.json)
         return f"Submitted job {job_id} with future {future}"

--- a/data_processing/services/radiology_service.py
+++ b/data_processing/services/radiology_service.py
@@ -42,8 +42,8 @@ executor = ProcessPoolExecutor(NUM_PROCS)
 extract_voxels_model = api.model("Resample and Extract Voxels", 
     {
         "job_tag": fields.String(description="Tag/name of output record", required=True, example='my_radiomics'),
-        "image_input_name": fields.String(description="Tag/name of input image record", required=True, example='generated_mhd'),
-        "label_input_name": fields.String(description="Tag/name of label image record", required=True, example='user_segmentations'),
+        "image_input_tag": fields.String(description="Tag/name of input image record", required=True, example='generated_mhd'),
+        "label_input_tag": fields.String(description="Tag/name of label image record", required=True, example='user_segmentations'),
         "resampledPixelSpacing": fields.List(fields.Float, description="Pixel resampling in mm in x,y,z", required=True, example=[1,1,1]),
     }
 )
@@ -52,8 +52,8 @@ extract_voxels_model = api.model("Resample and Extract Voxels",
 extract_radiomics_model = api.model("Extract Radiomics", 
     {
         "job_tag": fields.String(description="Tag/name of output record", required=True, example='my_radiomics'),
-        "image_input_name": fields.String(description="Tag/name of input image record", required=True, example='generated_mhd'),
-        "label_input_name": fields.String(description="Tag/name of label image record", required=True, example='user_segmentations'),
+        "image_input_tag": fields.String(description="Tag/name of input image record", required=True, example='generated_mhd'),
+        "label_input_tag": fields.String(description="Tag/name of label image record", required=True, example='user_segmentations'),
         "enableAllImageTypes": fields.Boolean(description="Toggle all images", required=False, example=False),
         "RadiomicsFeatureExtractor": fields.Raw(description="Key-value pairs for radiomics feature extractor", required=False, example={"interpolator": 'sitkBSpline'}),
     }
@@ -63,10 +63,10 @@ extract_radiomics_model = api.model("Extract Radiomics",
 window_dicom_model = api.model("Scale and Window CT Dicom Datasets",
     {
         "job_tag": fields.String(description="Tag/name of output record", required=True, example='my_windowed_dicoms'),
-        "input_name": fields.String(description="Tag/name of input image record", required=True, example='dicoms'),
+        "dicom_input_tag": fields.String(description="Tag/name of input image record", required=True, example='dicoms'),
         "window": fields.Boolean(description="Toggle window function", required=False, example=True),
-        "window.low_level": fields.Float(description="Low window value", required=False, example=-100),
-        "window.high_level": fields.Float(description="High window value", required=False, example=100),
+        "window_low_level":  fields.Float(description="Low window value", required=False,  example=-100),
+        "window_high_level": fields.Float(description="High window value", required=False, example=100),
     }
 )
 
@@ -74,8 +74,8 @@ window_dicom_model = api.model("Scale and Window CT Dicom Datasets",
 generate_scan_model = api.model("Generate Volumetric Image",
     {
         "job_tag": fields.String(description="Tag/name of output record", required=True, example='my_nrrd'),
-        "input_name": fields.String(description="Tag/name of input image record", required=True, example='dicoms'),
-        "file_ext": fields.String(description="A valid ITK image file extention", required=True, example='nrrd'),
+        "dicom_input_tag": fields.String(description="Tag/name of input image record", required=True, example='dicoms'),
+        "itkImageType": fields.String(description="A valid ITK image file extention", required=True, example='nrrd'),
     }
 )
 

--- a/data_processing/services/radiology_service.py
+++ b/data_processing/services/radiology_service.py
@@ -1,0 +1,114 @@
+'''
+Created: February 2021
+@author: aukermaa@mskcc.org
+
+Given a scan (container) ID
+1. resolve the path to the dicom folder
+2. for all dicoms, rescale into HU and optionally window
+3. store results on HDFS and add metadata to the graph
+
+'''
+# General imports
+import os, sys, subprocess, uuid
+import click
+from concurrent.futures import ProcessPoolExecutor
+
+# Server imports
+from flask import Flask, request, jsonify, render_template, make_response
+from flask_restx import Api, Resource, fields
+
+# From common
+from data_processing.common.config          import ConfigSet
+from data_processing.common.custom_logger   import init_logger
+from data_processing.common.Container       import Container
+from data_processing.common.Node            import Node
+from data_processing.common.utils           import get_method_data
+
+from data_processing.scanManager.windowDicoms       import window_dicom_with_container
+from data_processing.scanManager.extractRadiomics   import extract_radiomics_with_container
+from data_processing.scanManager.generateScan       import generate_scan_with_container
+
+logger = init_logger("radiology-service.log")
+    
+cfg = ConfigSet("APP_CFG",  config_file="config.yaml")
+VERSION      = "branch:"+subprocess.check_output(["git","rev-parse" ,"--abbrev-ref", "HEAD"]).decode('ascii').strip()
+HOSTNAME     = os.environ["HOSTNAME"]
+PORT         = int(cfg.get_value("APP_CFG::radiology_service_port"))
+NUM_PROCS    = int(cfg.get_value("APP_CFG::radiology_service_processes"))
+
+app = Flask(__name__)
+api = Api(app, version=VERSION, title='MIND Radiology Processing Service', description='Job-style endpoints for radiology image processing', ordered=True)
+executor = ProcessPoolExecutor(NUM_PROCS) 
+
+
+# param models
+extract_radiomics_model = api.model("Extract Radiomics Job",
+    {
+        "job_tag": fields.String(description="Tag/name of output record", required=True, example='my-radiomics'),
+        "image_input_name": fields.String(description="Tag/name of input image record", required=True, example='mhd'),
+        "label_input_name": fields.String(description="Tag/name of label image record", required=True, example='mha'),
+        "enableAllImageTypes": fields.Boolean(description="Toggle all images", required=False, example=False),
+        "RadiomicsFeatureExtractor": fields.String(description="Key-value pairs for radiomics feature extractor", required=False, example={"interpolator": 'sitkBSpline'}),
+    }
+)
+
+# param models
+window_dicom_model = api.model("Window/Convert Dicom CTs",
+    {
+        "job_tag": fields.String(description="Tag/name of output record", required=True, example='my-windowed-dicoms'),
+        "input_name": fields.String(description="Tag/name of input image record", required=True, example='mhd'),
+        "window": fields.Boolean(description="Toggle window function", required=False, example=True),
+        "window.low_level": fields.Float(description="Low window value", required=False, example=-100),
+        "window.high_level": fields.Float(description="High window value", required=False, example=100),
+    }
+)
+
+# param models
+generate_scan_model = api.model("Generate Volumetric Image",
+    {
+        "job_tag": fields.String(description="Tag/name of output record", required=True, example='my-nrrd'),
+        "input_name": fields.String(description="Tag/name of input image record", required=True, example='dicoms'),
+        "file_ext": fields.String(description="A valid ITK image file extention", required=True, example='nrrd'),
+    }
+)
+
+@api.route('/mind/api/v1/window_dicom/<cohort_id>/<container_id>/submit', methods=['POST'])
+class API_window_dicom(Resource):
+    @api.expect(window_dicom_model)
+    def post(self, cohort_id, container_id):
+        """Submit job"""
+        job_id = str(uuid.uuid4())
+        future = executor.submit (window_dicom_with_container, cohort_id, container_id, request.json)
+        return f"Submitted job {job_id} with future {future}"
+
+@api.route('/mind/api/v1/extract_radiomics/<cohort_id>/<container_id>/submit', methods=['POST'])
+class API_extract_radiomics(Resource):
+    @api.expect(extract_radiomics_model)
+    def post(self, cohort_id, container_id):
+        """Submit job"""
+        job_id = str(uuid.uuid4())
+        future = executor.submit (extract_radiomics_with_container, cohort_id, container_id, request.json)
+        return f"Submitted job {job_id} with future {future}"
+
+@api.route('/mind/api/v1/generate_scan/<cohort_id>/<container_id>/submit', methods=['POST'])
+class API_generate_scan(Resource):
+    @api.expect(generate_scan_model)
+    def post(self, cohort_id, container_id):
+        """Submit job"""
+        job_id = str(uuid.uuid4())
+        future = executor.submit (generate_scan_with_container, cohort_id, container_id, request.json)
+        return f"Submitted job {job_id} with future {future}"
+
+
+@api.route('/service/health', methods=['GET'])
+class API_heatlh(Resource):
+    def get(self):
+        return make_response("I'm doing okay! :)")
+
+if __name__ == '__main__':
+    # Setup App/Api
+    if sys.argv[1] == "start":
+        logger.info(f"Running in API mode")
+        logger.info(f"Starting worker on {HOSTNAME}:{PORT}")
+        app.run(host=HOSTNAME,port=PORT, debug=True)
+

--- a/data_processing/services/radiology_service.py
+++ b/data_processing/services/radiology_service.py
@@ -86,7 +86,7 @@ class API_window_dicom(Resource):
         """Submit a scale and window CT dicom Job"""
         job_id = str(uuid.uuid4())
         future = executor.submit (window_dicom_with_container, cohort_id, container_id, request.json)
-        return make_response( f"Submitted job {job_id} with future {future}", 202)
+        return make_response( {"message": f"Submitted job {job_id} with future {future}", "job_id": job_id }, 202 )
 
 @api.route('/mind/api/v1/extract_voxels/<cohort_id>/<container_id>/submit', methods=['POST'])
 class API_extract_voxels(Resource):
@@ -94,7 +94,7 @@ class API_extract_voxels(Resource):
     def post(self, cohort_id, container_id):
         """Submit an extract radiomics Job"""
         job_id = str(uuid.uuid4())
-        return make_response( "Not implimented yet", 402 )
+        return make_response( "Not implimented yet", 400 )
         #future = executor.submit (extract_voxels_with_container, cohort_id, container_id, request.json)
         #return make_response( f"Submitted job {job_id} with future {future}"
 
@@ -105,7 +105,7 @@ class API_extract_radiomics(Resource):
         """Submit an extract radiomics Job"""
         job_id = str(uuid.uuid4())
         future = executor.submit (extract_radiomics_with_container, cohort_id, container_id, request.json)
-        return make_response( f"Submitted job {job_id} with future {future}", 202 )
+        return make_response( {"message": f"Submitted job {job_id} with future {future}", "job_id": job_id }, 202 )
 
 @api.route('/mind/api/v1/generate_scan/<cohort_id>/<container_id>/submit', methods=['POST'])
 class API_generate_scan(Resource):
@@ -114,7 +114,7 @@ class API_generate_scan(Resource):
         """Submit a generate scan Job"""
         job_id = str(uuid.uuid4())
         future = executor.submit (generate_scan_with_container, cohort_id, container_id, request.json)
-        return make_response( f"Submitted job {job_id} with future {future}", 202 )
+        return make_response( {"message": f"Submitted job {job_id} with future {future}", "job_id": job_id }, 202 )
 
 
 @api.route('/service/health', methods=['GET'])

--- a/tests/data_processing/radiology/common/test_preprocess.py
+++ b/tests/data_processing/radiology/common/test_preprocess.py
@@ -82,7 +82,7 @@ def test_generate_scan_1(tmp_path):
     properties = generate_scan(
         dicom_path = f'{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/dicoms/',
         output_dir = tmp_path,
-        params     = {'file_ext':'mhd'}
+        params     = {'itkImageType':'mhd'}
     )
     #assert output_node.properties['hash'] == 'eb8574fa61db82aa085ba7c05739d99519b140ca73da95920b887f6bcdba6a9c'
     assert properties['zdim'] == 9
@@ -93,7 +93,7 @@ def test_generate_scan_2(tmp_path):
     properties = generate_scan(
         dicom_path = f'{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/dicoms/',
         output_dir = tmp_path,
-        params     = {'file_ext':'nrrd'}
+        params     = {'itkImageType':'nrrd'}
     )
     #assert output_node.properties['hash'] == '53b504fb8fee82e3065104634965fe517cd27c97da97f60057e872c020656262'
     assert properties['zdim'] == 9
@@ -120,7 +120,7 @@ def test_window_dicoms_2(tmp_path):
     properties = window_dicoms(
         dicom_paths = list(pathlib.Path(f'{cwd}/tests/data_processing/testdata/data/2.000000-CTAC-24716/dicoms/').glob("*.dcm")),
         output_dir = tmp_path,
-        params     = {'window':True, 'window.low_level': -100, 'window.high_level': 100}
+        params     = {'window':True, 'window_low_level': -100, 'window_high_level': 100}
     )
     #assert output_node.properties['hash'] == '5624a11d08ab8ef4e66e3fd9307e775bf8bbad7d0759aab893d1648d7c60ae19'
     print (properties)


### PR DESCRIPTION
Basic prototype done, new file  data_processing/services/radiology_service.py
* Accepts job input/config
* Submits/queues job in background

<img width="1330" alt="Screen Shot 2021-02-23 at 5 07 55 PM" src="https://user-images.githubusercontent.com/25043162/108914657-af1aae80-75f9-11eb-8976-b459ce1f3211.png">

Major changes:

 data_processing/common/Container.py
* Added configuration using configset/config.yaml, removed all hard-coded params
* If a connection to an object store is configured, files are uploaded during the save process

 data_processing/scanManager/*py
* Update using configset
* Generalize main function to accept params as a dictionary, adapt CLI tool to load a json and pass a dictonary

 data_processing/scanManager/config.py
* Added method to return configuration dictonary

