### PR TITLE
Completion work from slide ingestion tests

### DIFF
--- a/data_processing/common/constants.py
+++ b/data_processing/common/constants.py
@@ -48,6 +48,7 @@ def PROJECT_LOCATION(cfg):
     :param cfg:
     :return: ROOT_PATH/PROJECT_NAME
     """
+    # This function assumes <uri_root>/data as "ROOT_PATH"
     return os.path.join(cfg.get_value(path=DATA_CFG+'::ROOT_PATH'), cfg.get_value(path=DATA_CFG+'::PROJECT'))
 
 

--- a/data_processing/pathology/proxy_table/generate.py
+++ b/data_processing/pathology/proxy_table/generate.py
@@ -14,6 +14,8 @@ from data_processing.common.custom_logger import init_logger
 from data_processing.common.sparksession import SparkConfig
 import data_processing.common.constants as const
 from data_processing.common.utils import generate_uuid
+from data_processing.common.Container import Container 
+from data_processing.common.Container import Node 
 
 from pyspark.sql.functions import udf, lit, col, array
 from pyspark.sql.types import StringType, MapType
@@ -22,6 +24,7 @@ import shutil, sys, importlib, glob, yaml, os, subprocess, time
 from pathlib import Path
 
 import openslide 
+import requests 
 
 logger = init_logger()
 
@@ -82,13 +85,13 @@ def cli(template_file, config_file, process_string):
         logger.info('processes: ' + str(processes))
 
         # load configs
-        cfg = ConfigSet(name=DATA_CFG, config_file=template_file, schema_file=SCHEMA_FILE)
-        cfg = ConfigSet(name=APP_CFG,  config_file=config_file)
+        cfg = ConfigSet(name="APP_CFG",  config_file=config_file)
+        cfg = ConfigSet(name="DATA_CFG", config_file=template_file, schema_file=SCHEMA_FILE)
 
         # write template file to manifest_yaml under LANDING_PATH
         # todo: write to hdfs without using local gpfs/
         hdfs_path = os.environ['MIND_GPFS_DIR']
-        landing_path = cfg.get_value(path=DATA_CFG+'::LANDING_PATH')
+        landing_path = cfg.get_value(path='DATA_CFG::LANDING_PATH')
         
         full_landing_path = os.path.join(hdfs_path, landing_path)     
         if not os.path.exists(full_landing_path):
@@ -102,6 +105,11 @@ def cli(template_file, config_file, process_string):
             if exit_code != 0:
                 logger.error("Delta table creation had errors. Exiting.")
                 return
+        if 'graph' in processes or 'all' in processes:
+            exit_code = update_graph(config_file)
+            if exit_code != 0:
+                logger.error("Graph creation had errors. Exiting.")
+                return
 
 
 def create_proxy_table(config_file):
@@ -111,13 +119,12 @@ def create_proxy_table(config_file):
     spark = SparkConfig().spark_session(config_name=APP_CFG, app_name="data_processing.pathology.proxy_table.generate")
 
     logger.info("generating binary proxy table... ")
-    wsi_path  = const.TABLE_LOCATION(cfg)
-    write_uri = os.environ["HDFS_URI"]
-    save_path = os.path.join(write_uri, wsi_path)
+    save_path = const.TABLE_LOCATION(cfg)
+    logger.info ("Writing to %s", save_path)
 
     with CodeTimer(logger, 'load wsi metadata'):
 
-        search_path = os.path.join(cfg.get_value(path=DATA_CFG+'::SOURCE_PATH'), ("**" + cfg.get_value(path=DATA_CFG+'::FILE_TYPE')))
+        search_path = os.path.join(cfg.get_value(path='DATA_CFG::SOURCE_PATH'), ("**" + cfg.get_value(path='DATA_CFG::FILE_TYPE')))
         logger.debug(search_path)
         for path in glob.glob(search_path, recursive=True):
             logger.debug(path)
@@ -128,9 +135,9 @@ def create_proxy_table(config_file):
         parse_openslide_udf = udf(parse_openslide, MapType(StringType(), StringType()))
 
         df = spark.read.format("binaryFile"). \
-            option("pathGlobFilter", "*."+cfg.get_value(path=DATA_CFG+'::FILE_TYPE')). \
+            option("pathGlobFilter", "*."+cfg.get_value(path='DATA_CFG::FILE_TYPE')). \
             option("recursiveFileLookup", "true"). \
-            load(cfg.get_value(path=DATA_CFG+'::SOURCE_PATH')). \
+            load(cfg.get_value(path='DATA_CFG::SOURCE_PATH')). \
             drop("content").\
             withColumn("wsi_record_uuid", generate_uuid_udf  (col("path"), array(lit("WSI")))).\
             withColumn("slide_id",        parse_slide_id_udf (col("path"))).\
@@ -141,10 +148,48 @@ def create_proxy_table(config_file):
     df.coalesce(48).write.format("delta").save(save_path)
 
     processed_count = df.count()
-    logger.info("Processed {} whole slide images out of total {} files".format(processed_count,cfg.get_value(path=DATA_CFG+'::FILE_COUNT')))
+    logger.info("Processed {} whole slide images out of total {} files".format(processed_count,cfg.get_value(path='DATA_CFG::FILE_COUNT')))
     return exit_code
 
+def update_graph(config_file):
+    """
+    This function reads a delta table and:
+        1. Creates/validates a cohort-namespace exists given the PROJECT name
+        2. Creates slide containers for each slide_id, and 
+        3. Commits associated metadata/raw data to neo4j/minio
+    """
 
+    exit_code = 0
+    cfg  = ConfigSet()
+    spark = SparkConfig().spark_session(config_name=APP_CFG, app_name="data_processing.pathology.proxy_table.generate")
+
+    table_path = const.TABLE_LOCATION(cfg)
+
+    namespace            = cfg.get_value("DATA_CFG::PROJECT")
+    api_base_url         = cfg.get_value("APP_CFG::api_base_url")
+    cohort_service_host  = cfg.get_value("APP_CFG::cohortManager_host")
+    cohort_service_port  = cfg.get_value("APP_CFG::cohortManager_port")
+    cohort_uri           = f"http://{cohort_service_host}:{cohort_service_port}{api_base_url}"
+
+    logger.info ("Requesting %s, %s", os.path.join(cohort_uri, "cohort", namespace), requests.put(os.path.join(cohort_uri, "cohort", namespace)).text)
+
+    with CodeTimer(logger, 'setup proxy table'):
+        # Reading dicom and opdata
+        logger.info("Loading %s:", table_path)
+        tuple_to_add = spark.read.format("delta").load(table_path).select("slide_id", "path", "metadata").toPandas()
+
+    with CodeTimer(logger, 'synchronize lake'):
+        container = Container( cfg ).setNamespace(namespace)
+        for _, row in tuple_to_add.iterrows():
+            logger.info ("Requesting %s, %s", os.path.join(cohort_uri, "container", "slide", row.slide_id), requests.put(os.path.join(cohort_uri, "container", "slide", row.slide_id)).text)
+            container.lookupAndAttach(row.slide_id)
+            properties = row.metadata
+            properties['file'] = row.path.split(':')[-1]
+            node = Node("wsi", "whole_slide_image", properties)
+            container.add(node)
+        container.saveAll()
+
+    return exit_code
 
 if __name__ == "__main__":
     cli()

--- a/data_processing/scanManager/extractRadiomics.py
+++ b/data_processing/scanManager/extractRadiomics.py
@@ -24,7 +24,7 @@ from data_processing.common.config import ConfigSet
 from data_processing.radiology.common.preprocess   import extract_radiomics
 
 logger = init_logger("extractRadiomics.log")
-cfg = ConfigSet("CONTAINER_CFG",  config_file="config.yaml")
+cfg = ConfigSet("APP_CFG",  config_file="config.yaml")
 
 @click.command()
 @click.option('-c', '--cohort_id',    required=True)

--- a/data_processing/scanManager/extractVoxels.py
+++ b/data_processing/scanManager/extractVoxels.py
@@ -26,7 +26,7 @@ from data_processing.radiology.common.preprocess   import extract_voxels
 from medpy.io import load
 
 logger = init_logger("extractVoxels.log")
-cfg = ConfigSet("CONTAINER_CFG",  config_file="config.yaml")
+cfg = ConfigSet("APP_CFG",  config_file="config.yaml")
 
 @click.command()
 @click.option('-c', '--cohort_id',    required=True)

--- a/data_processing/scanManager/generateScan.py
+++ b/data_processing/scanManager/generateScan.py
@@ -24,7 +24,7 @@ from data_processing.common.config import ConfigSet
 from data_processing.radiology.common.preprocess import generate_scan
 
 logger = init_logger("generateScan.log")
-cfg = ConfigSet("CONTAINER_CFG",  config_file="config.yaml")
+cfg = ConfigSet("APP_CFG",  config_file="config.yaml")
 
 @click.command()
 @click.option('-c', '--cohort_id',    required=True)

--- a/data_processing/scanManager/scanManager.py
+++ b/data_processing/scanManager/scanManager.py
@@ -29,11 +29,6 @@ Config.yaml:
     - scanManager_port      - What port to publish API
     - scanManager_processes - Number of concurrent jobs
 """
-container_params = {
-        'GRAPH_URI':  os.environ['GRAPH_URI'],
-        'GRAPH_USER': "neo4j",
-        'GRAPH_PASSWORD': "password"
-    }
 
 # Setup configurations
 cfg = ConfigSet("APP_CFG",  config_file="config.yaml")
@@ -127,7 +122,7 @@ class manageContainer(Resource):
         except:
             return make_response("Failed to configure node, bad type???", 401)
 
-        container = Container( container_params ).setNamespace(cohort_id).lookupAndAttach(container_id)
+        container = Container( cfg ).setNamespace(cohort_id).lookupAndAttach(container_id)
         container.add(n_data)
         container.saveAll()
 
@@ -135,11 +130,11 @@ class manageContainer(Resource):
         return make_response(f"Added {n_data.get_match_str()} to container {container_id}", 200)
 
 
-@api.route('/mind/api/v1/methods/<cohort_id>/<method_id>/run', 
+@api.route('/mind/api/v1/methods/<cohort_id>/run', 
     methods=['POST'],
     doc={"description": "Add new or view current namespace methods"}
 )
-@api.route('/mind/api/v1/methods/<cohort_id>/<method_id>/<container_id>/run', 
+@api.route('/mind/api/v1/methods/<cohort_id>/<container_id>/run', 
     methods=['POST'],
     doc={"description": "Add new or view current namespace methods"}
 )
@@ -148,7 +143,7 @@ class manageContainer(Resource):
     responses={200:"Success", 400: "Method already exists"}
 )
 class runMethods(Resource):
-    def post(self, cohort_id, method_id, container_id=None):
+    def post(self, cohort_id, container_id=None):
         """ Run a method """
         n_cohort = Node("cohort", cohort_id)
 
@@ -332,11 +327,11 @@ class initScans(Resource):
             count += 1
 
             properties = dict(row)
-            properties['path'] = os.path.split(properties['path'])[0]
+            properties['path'] = os.path.split(properties['path'])[0].split(':')[-1]
 
             n_meta = Node("dicom", 'init-scans', properties=properties)
             
-            container = Container( container_params ).setNamespace(cohort_id).lookupAndAttach(row['SeriesInstanceUID'])
+            container = Container( cfg ).setNamespace(cohort_id).lookupAndAttach(row['SeriesInstanceUID'])
             container.add(n_meta)
             container.saveAll()
 

--- a/data_processing/scanManager/windowDicoms.py
+++ b/data_processing/scanManager/windowDicoms.py
@@ -24,7 +24,7 @@ from data_processing.common.config import ConfigSet
 from data_processing.radiology.common.preprocess import window_dicoms
 
 logger = init_logger("windowDicoms.log")
-cfg = ConfigSet("CONTAINER_CFG",  config_file="config.yaml")
+cfg = ConfigSet("APP_CFG",  config_file="config.yaml")
 
 @click.command()
 @click.option('-c', '--cohort_id',    required=True)

--- a/tests/data_processing/common/test_graph_enum.py
+++ b/tests/data_processing/common/test_graph_enum.py
@@ -43,7 +43,7 @@ def test_metadata_create():
 
     create_string = Node("mhd", "SCAN-001", properties=properties).get_create_str()
     assert "mhd:globals" in create_string    
-    assert "qualified_address: 'my_cohort::SCAN-001'"  in create_string
+    assert "qualified_address: 'my_cohort::scan-001'"  in create_string
     assert "dim"  in create_string
 
 def test_metadata_match():
@@ -51,8 +51,8 @@ def test_metadata_match():
     properties['namespace'] = "my_cohort"
     properties['dim'] = 3
 
-    match_string = Node("mhd", "SCAN-001", properties=properties).get_match_str()
-    assert "qualified_address: 'my_cohort::SCAN-001'"  in match_string
+    match_string = Node("mhd", "SCAN-002", properties=properties).get_match_str()
+    assert "qualified_address: 'my_cohort::scan-002"  in match_string
     assert "dim"  not in match_string
 
 
@@ -67,7 +67,7 @@ def test_get_all_properties():
 
 def test_patient_no_namespace():
     node = Node("patient", "pid", properties={})
-    assert node.properties['namespace'] == 'default'
+    assert node.properties['qualified_address'] == 'pid'
 
 def test_cohort_wrong_properties():
     with pytest.raises(TypeError):

--- a/tests/data_processing/pathology/proxy_table/test_generate.py
+++ b/tests/data_processing/pathology/proxy_table/test_generate.py
@@ -33,7 +33,8 @@ def test_cli(spark):
     runner = CliRunner()
     result = runner.invoke(cli, 
         ['-t', 'tests/data_processing/pathology/proxy_table/data.yaml',
-        '-f', 'tests/test_config.yaml'])
+        '-f', 'tests/test_config.yaml',
+        '-p', 'delta'])
 
     assert result.exit_code == 0
 

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -21,3 +21,25 @@ spark_application_config:
   - spark.sql.shuffle.partitions: 60
 
   - spark.driver.maxResultSize: 2g
+
+
+api_version: 1.1
+scanManager_port: 5001
+getPathologyAnnotations_port: 5002
+scanManager_port: 5003
+cohortManager_port: 5004
+radiology_library_port: 5005
+radiology_service_port: 5006
+scanManager_processes: 16
+radiology_service_processes: 16
+
+GRAPH_URI: neo4j://localhost:7687
+GRAPH_USER: neo4j
+GRAPH_PASSWORD: password
+
+OBJECT_STORE_ENABLED: True
+MINIO_URI: localhost:8002
+MINIO_USER: minio 
+MINIO_PASSWORD: password 
+
+


### PR DESCRIPTION
Some observations:
* Generally the ingestion works seamlessly for a random TCGA dataset, which is good news.  It has a different file structure than our MIND pathology folders, different source, naming convention, etc.
* Issues with making new directories, a permissions problem.  Must manually create the project folder as root and chmod
* A lot of seemingly unused fields in the data ingestio template/schema 
* A landing path of data/my_project is not correct as the infrastructure assumes things live under data/
* How paths, especially root/prefix paths, are handled is not uniform.  There are a couple different params that all do similar, but different things: HDFS_URI, MIND_ROOT_DIR, ROOT_DIR, data vs data/, project location -- we should try and harmonize this and also separate out user/data-specific configuration from constants or assumed configuration.
* No graph method, however this was pretty easy to add. 
* It was kinda cool to not do much actual work to learn a bit about these slides, e.g. that they were 40x resolution!

PR mostly completes/cleanups pathology slide ingestion.

data_processing/pathology/proxy_table/generate.py
* Add graph logic/code
* Some cleanup

tests:
* Only test delta table creation