### PR TITLE
Generate/collect tiles for training

### DIFF
--- a/data_processing/common/Container.py
+++ b/data_processing/common/Container.py
@@ -267,8 +267,8 @@ class Container(object):
             return None
         else:
             node = Node(res[0]['data']['type'], res[0]['data']['name'], dict(res[0]['data'].items()))
-            self.logger.info ("Query Successful:")
-            self.logger.info (node)
+            # self.logger.info ("Query Successful:")
+            # self.logger.info (node)
 
         
         # Parse path (filepath) URI: more sophistic path logic to come (pulling from S3, external mounts, etc!!!!)

--- a/data_processing/common/Container.py
+++ b/data_processing/common/Container.py
@@ -88,7 +88,7 @@ class Container(object):
             self._client = Minio(params['MINIO_URI'], access_key=params['MINIO_USER'], secret_key=params['MINIO_PASSWORD'], secure=False)
             try:
                 for bucket in self._client.list_buckets():
-                    self.logger.info("Found bucket %s", bucket.name )
+                    self.logger.debug("Found bucket %s", bucket.name )
                 self.logger.info("OBJECT_STORE_ENABLED=True")
                 params['OBJECT_STORE_ENABLED'] = True
             except:
@@ -251,7 +251,7 @@ class Container(object):
 
         query = f"""MATCH (container)-[:HAS_DATA]-(data:{type}) WHERE id(container) = {self._container_id} AND data.name='{name}' AND data.namespace='{self._namespace_id}' RETURN data"""
 
-        self.logger.info(query)
+        self.logger.debug(query)
         res = self._conn.query(query)
 
         # Catches bad queries
@@ -267,8 +267,8 @@ class Container(object):
             return None
         else:
             node = Node(res[0]['data']['type'], res[0]['data']['name'], dict(res[0]['data'].items()))
-            # self.logger.info ("Query Successful:")
-            # self.logger.info (node)
+            self.logger.debug ("Query Successful:")
+            self.logger.debug (node)
 
         
         # Parse path (filepath) URI: more sophistic path logic to come (pulling from S3, external mounts, etc!!!!)
@@ -313,14 +313,14 @@ class Container(object):
         node.objects = []
         if "path" in node.properties.keys() and self.params.get("OBJECT_STORE_ENABLED", False):
             node.properties['object_bucket'] = f"{self._bucket_id}"
-            node.properties['object_folder'] = f"{self._name}/{node.name}"
+            node.properties['object_folder'] = f"{node.name}/{self._name}"
             for path in pathlib.Path(node.properties['path']).glob("*"): node.objects.append(path)        
             self.logger.info ("Node has %s pending object commits",  len(node.objects))
 
         if "file" in node.properties.keys() and self.params.get("OBJECT_STORE_ENABLED", False):
             node.properties['path'] = node.properties['file']
             node.properties['object_bucket'] = f"{self._bucket_id}"
-            node.properties['object_folder'] = f"{self._name}/{node.name}"
+            node.properties['object_folder'] = f"{node.name}/{self._name}"
             node.objects.append(pathlib.Path(node.properties['path']))
             self.logger.info ("Node has %s pending object commits",  len(node.objects))
 
@@ -360,8 +360,7 @@ class Container(object):
                 object_bucket = n.properties.get("object_bucket")
                 object_folder = n.properties.get("object_folder")
                 for p in n.objects:
-                    # self.logger.info("Submitting: %s", f"minio/{object_bucket}/{object_folder}/{p.name}")
-                    future = executor.submit(self._client.fput_object, object_bucket, f"{object_folder}/{p.name}", p, part_size=250000000)
+                    future = executor.submit(self._client.fput_object, object_bucket, f"{object_folder}_{p.name}", p, part_size=250000000)
                     future_uploads.append(future)
         
         n_count_futures = 0

--- a/data_processing/common/Container.py
+++ b/data_processing/common/Container.py
@@ -285,6 +285,8 @@ class Container(object):
                 node.path = pathlib.Path(path.split(":")[-1])
             else:
                 node.path = pathlib.Path(path)
+            
+            node.static_path = str(node.path)
         
             # Output and check
             self.logger.info ("Resolved %s -> %s", node.properties["path"], node.path)

--- a/data_processing/common/Node.py
+++ b/data_processing/common/Node.py
@@ -1,5 +1,6 @@
 from data_processing.common.utils import to_sql_field, to_sql_value, does_not_contain
 import warnings, os
+from pathlib import Path
 
 class Node(object):
 	"""
@@ -33,6 +34,8 @@ class Node(object):
 
 		self.properties["type"] = self.type
 
+		self.path = None
+
 	def set_namespace(self, namespace_id: str, subspace_id=None):
 		"""
 		Sets the namespace for this Node commits
@@ -47,6 +50,15 @@ class Node(object):
 		else:
 			self.properties['subspace']  = subspace_id
 			self.properties["qualified_address"] = self.get_qualified_name(self.properties['namespace'], self.properties['subspace'], self.name)
+
+
+	def get_path(self, type='string'):
+		"""
+		Returns node's current path
+		"""
+		if self.path is None: raise RuntimeError("Node's path was never set, however was accessed!")
+		elif type=='string':  return str ( self.path )
+		elif type=='pathlib': return Path( self.path )
 
 
 	def __repr__(self):

--- a/data_processing/pathology/cli/collect_tiles.py
+++ b/data_processing/pathology/cli/collect_tiles.py
@@ -65,17 +65,17 @@ def visualize_tile_labels_with_container(cohort_id: str, container_id: str, meth
         output_dir = os.path.join(os.environ['MIND_GPFS_DIR'], "data", container._namespace_id, container._name, method_id)
         if not os.path.exists(output_dir): os.makedirs(output_dir)
 
-        save_tiles_parquet(str(image_node.path), str(label_node.path),output_dir, method_data )
+        properties = save_tiles_parquet(str(image_node.path), str(label_node.path),output_dir, method_data )
 
     except Exception:
         container.logger.exception ("Exception raised, stopping job execution.")
     else:
-        parquet_container = Container( cfg ).setNamespace(cohort_id).lookupAndAttach(output_container_id)
+        #parquet_container = Container( cfg ).setNamespace(cohort_id).lookupAndAttach(output_container_id)
 
-        output_node = Node("parquet", method_id, properties)
+        output_node = Node("TileImages", method_id, properties)
         logger.info(output_node) 
-        # container.add(output_node)
-        # container.saveAll()
+        container.add(output_node)
+        container.saveAll()
 
 
 if __name__ == "__main__":

--- a/data_processing/pathology/cli/collect_tiles.py
+++ b/data_processing/pathology/cli/collect_tiles.py
@@ -3,15 +3,15 @@ Created: February 2021
 @author: aukermaa@mskcc.org
 
 Given a slide (container) ID
-1. resolve the path to the WSI image
+1. resolve the path to the WsiImage and TileLabels
 2. perform various scoring and labeling to tiles
-3. save tiles as a csv with schema [address, coordinates, *scores, *labels ]
+3. save tiles as a parquet file with schema [address, coordinates, *scores, *labels ]
 
 Example:
-python3 -m data_processing.pathology.cli.visualize_tile_labels \
+python3 -m data_processing.pathology.cli.collect_tiles \
     -c TCGA-BRCA \
     -s tcga-gm-a2db-01z-00-dx1.9ee36aa6-2594-44c7-b05c-91a0aec7e511 \
-    -m data_processing/pathology/cli/example_visualize_tile_labels.json
+    -m data_processing/pathology/cli/example_collect_tiles.json
 '''
 
 # General imports
@@ -25,8 +25,7 @@ from data_processing.common.Container       import Container
 from data_processing.common.Node            import Node
 from data_processing.common.config          import ConfigSet
 
-# From radiology.common
-from data_processing.pathology.common.preprocess   import visualize_scoring
+from data_processing.pathology.common.preprocess      import save_tiles_parquet
 
 logger = init_logger("visualize_tile_labels.log")
 cfg = ConfigSet("APP_CFG",  config_file="config.yaml")
@@ -46,14 +45,16 @@ def visualize_tile_labels_with_container(cohort_id: str, container_id: str, meth
     """
 
     # Do some setup
-    container   = Container( cfg ).setNamespace(cohort_id).lookupAndAttach(container_id)
-    method_id   = method_data.get("job_tag", "none")
+    container = Container( cfg ).setNamespace(cohort_id).lookupAndAttach(container_id)
+
+    method_id            = method_data.get("job_tag", "none")
+    output_container_id  = method_data.get("output_container")
 
     image_node  = container.get("wsi", method_data['input_wsi_tag']) 
     label_node  = container.get("TileScores", method_data['input_label_tag']) 
 
+    # Add properties to method_data
     method_data.update(label_node.properties)
-
 
     try:
         if image_node is None:
@@ -64,14 +65,17 @@ def visualize_tile_labels_with_container(cohort_id: str, container_id: str, meth
         output_dir = os.path.join(os.environ['MIND_GPFS_DIR'], "data", container._namespace_id, container._name, method_id)
         if not os.path.exists(output_dir): os.makedirs(output_dir)
 
-        properties = visualize_scoring(str(image_node.path), str(label_node.path), output_dir, method_data)
+        save_tiles_parquet(str(image_node.path), str(label_node.path),output_dir, method_data )
 
     except Exception:
         container.logger.exception ("Exception raised, stopping job execution.")
     else:
-        output_node = Node("TileScores", method_id, properties)
-        container.add(output_node)
-        container.saveAll()
+        parquet_container = Container( cfg ).setNamespace(cohort_id).lookupAndAttach(output_container_id)
+
+        output_node = Node("parquet", method_id, properties)
+        logger.info(output_node) 
+        # container.add(output_node)
+        # container.saveAll()
 
 
 if __name__ == "__main__":

--- a/data_processing/pathology/cli/collect_tiles.py
+++ b/data_processing/pathology/cli/collect_tiles.py
@@ -65,7 +65,7 @@ def visualize_tile_labels_with_container(cohort_id: str, container_id: str, meth
         output_dir = os.path.join(os.environ['MIND_GPFS_DIR'], "data", container._namespace_id, container._name, method_id)
         if not os.path.exists(output_dir): os.makedirs(output_dir)
 
-        properties = save_tiles_parquet(str(image_node.path), str(label_node.path),output_dir, method_data )
+        properties = save_tiles_parquet(image_node.static_path, label_node.static_path, output_dir, method_data )
 
     except Exception:
         container.logger.exception ("Exception raised, stopping job execution.")

--- a/data_processing/pathology/cli/collect_tiles.py
+++ b/data_processing/pathology/cli/collect_tiles.py
@@ -65,7 +65,7 @@ def visualize_tile_labels_with_container(cohort_id: str, container_id: str, meth
         output_dir = os.path.join(os.environ['MIND_GPFS_DIR'], "data", container._namespace_id, container._name, method_id)
         if not os.path.exists(output_dir): os.makedirs(output_dir)
 
-        properties = save_tiles_parquet(image_node.static_path, label_node.static_path, output_dir, method_data )
+        properties = save_tiles_parquet(image_node.get_path(), label_node.get_path(), output_dir, method_data )
 
     except Exception:
         container.logger.exception ("Exception raised, stopping job execution.")

--- a/data_processing/pathology/cli/example_collect_tiles.json
+++ b/data_processing/pathology/cli/example_collect_tiles.json
@@ -1,0 +1,6 @@
+{
+  "input_wsi_tag": "whole_slide_image", 
+  "input_label_tag": "test_generate_tiles",
+  "job_tag": "test_collect_tiles",
+  "output_container": "test_tcga_parquet_tile_table_thing"
+}

--- a/data_processing/pathology/cli/example_collect_tiles.json
+++ b/data_processing/pathology/cli/example_collect_tiles.json
@@ -2,5 +2,5 @@
   "input_wsi_tag": "whole_slide_image", 
   "input_label_tag": "test_generate_tiles",
   "job_tag": "test_collect_tiles",
-  "output_container": "test_tcga_parquet_tile_table_thing"
+  "output_container": "test_output_dataset"
 }

--- a/data_processing/pathology/cli/example_generate_tile_labels.json
+++ b/data_processing/pathology/cli/example_generate_tile_labels.json
@@ -1,7 +1,7 @@
 {
   "input_wsi_tag": "whole_slide_image", 
   "job_tag": "test_generate_tiles",
-  "tile_size": 1280,
+  "tile_size": 64,
   "scale_factor": 20,
-  "magnification": 20 
+  "magnification": 4 
 }

--- a/data_processing/pathology/cli/example_generate_tile_labels.json
+++ b/data_processing/pathology/cli/example_generate_tile_labels.json
@@ -1,7 +1,7 @@
 {
   "input_wsi_tag": "whole_slide_image", 
   "job_tag": "test_generate_tiles",
-  "tile_size": 64,
-  "scale_factor": 20,
-  "magnification": 4 
+  "tile_size": 128,
+  "scale_factor": 8,
+  "magnification": 10 
 }

--- a/data_processing/pathology/cli/example_generate_tile_labels.json
+++ b/data_processing/pathology/cli/example_generate_tile_labels.json
@@ -1,7 +1,7 @@
 {
   "input_wsi_tag": "whole_slide_image", 
   "job_tag": "test_generate_tiles",
-  "tile_size": 64,
-  "scale_factor": 4,
-  "magnification": 4 
+  "tile_size": 1280,
+  "scale_factor": 20,
+  "magnification": 20 
 }

--- a/data_processing/pathology/cli/example_generate_tile_labels.json
+++ b/data_processing/pathology/cli/example_generate_tile_labels.json
@@ -1,7 +1,7 @@
 {
   "input_wsi_tag": "whole_slide_image", 
   "job_tag": "test_generate_tiles",
-  "tile_size": 2560,
-  "scale_factor": 16,
-  "magnification": 40 
+  "tile_size": 64,
+  "scale_factor": 4,
+  "magnification": 4 
 }

--- a/data_processing/pathology/cli/example_visualize_tile_labels.json
+++ b/data_processing/pathology/cli/example_visualize_tile_labels.json
@@ -2,5 +2,5 @@
   "input_wsi_tag": "whole_slide_image", 
   "input_label_tag": "test_generate_tiles",
   "job_tag": "test_visualize_tiles",
-  "scale_factor": 20 
+  "scale_factor": 10 
 }

--- a/data_processing/pathology/cli/example_visualize_tile_labels.json
+++ b/data_processing/pathology/cli/example_visualize_tile_labels.json
@@ -2,5 +2,5 @@
   "input_wsi_tag": "whole_slide_image", 
   "input_label_tag": "test_generate_tiles",
   "job_tag": "test_visualize_tiles",
-  "scale_factor": 10 
+  "scale_factor": 8 
 }

--- a/data_processing/pathology/cli/example_visualize_tile_labels.json
+++ b/data_processing/pathology/cli/example_visualize_tile_labels.json
@@ -2,7 +2,5 @@
   "input_wsi_tag": "whole_slide_image", 
   "input_label_tag": "test_generate_tiles",
   "job_tag": "test_visualize_tiles",
-  "tile_size": 2560,
-  "scale_factor": 50,
-  "magnification": 40 
+  "scale_factor": 4 
 }

--- a/data_processing/pathology/cli/example_visualize_tile_labels.json
+++ b/data_processing/pathology/cli/example_visualize_tile_labels.json
@@ -2,5 +2,5 @@
   "input_wsi_tag": "whole_slide_image", 
   "input_label_tag": "test_generate_tiles",
   "job_tag": "test_visualize_tiles",
-  "scale_factor": 4 
+  "scale_factor": 20 
 }

--- a/data_processing/pathology/cli/generate_tile_labels.py
+++ b/data_processing/pathology/cli/generate_tile_labels.py
@@ -60,7 +60,7 @@ def generate_tile_labels_with_container(cohort_id: str, container_id: str, metho
         output_dir = os.path.join(os.environ['MIND_GPFS_DIR'], "data", container._namespace_id, container._name, method_id)
         if not os.path.exists(output_dir): os.makedirs(output_dir)
 
-        properties = pretile_scoring(image_node.static_path, output_dir, method_data)
+        properties = pretile_scoring(image_node.get_path(), output_dir, method_data)
 
     except Exception:
         container.logger.exception ("Exception raised, stopping job execution.")

--- a/data_processing/pathology/cli/generate_tile_labels.py
+++ b/data_processing/pathology/cli/generate_tile_labels.py
@@ -60,7 +60,7 @@ def generate_tile_labels_with_container(cohort_id: str, container_id: str, metho
         output_dir = os.path.join(os.environ['MIND_GPFS_DIR'], "data", container._namespace_id, container._name, method_id)
         if not os.path.exists(output_dir): os.makedirs(output_dir)
 
-        properties = pretile_scoring(str(image_node.path), output_dir, method_data)
+        properties = pretile_scoring(image_node.static_path, output_dir, method_data)
 
     except Exception:
         container.logger.exception ("Exception raised, stopping job execution.")

--- a/data_processing/pathology/cli/visualize_tile_labels.py
+++ b/data_processing/pathology/cli/visualize_tile_labels.py
@@ -64,7 +64,7 @@ def visualize_tile_labels_with_container(cohort_id: str, container_id: str, meth
         output_dir = os.path.join(os.environ['MIND_GPFS_DIR'], "data", container._namespace_id, container._name, method_id)
         if not os.path.exists(output_dir): os.makedirs(output_dir)
 
-        properties = visualize_scoring(str(image_node.path), str(label_node.path), output_dir, method_data)
+        properties = visualize_scoring(image_node.static_path, label_node.static_path, output_dir, method_data)
 
     except Exception:
         container.logger.exception ("Exception raised, stopping job execution.")

--- a/data_processing/pathology/cli/visualize_tile_labels.py
+++ b/data_processing/pathology/cli/visualize_tile_labels.py
@@ -64,7 +64,7 @@ def visualize_tile_labels_with_container(cohort_id: str, container_id: str, meth
         output_dir = os.path.join(os.environ['MIND_GPFS_DIR'], "data", container._namespace_id, container._name, method_id)
         if not os.path.exists(output_dir): os.makedirs(output_dir)
 
-        properties = visualize_scoring(image_node.static_path, label_node.static_path, output_dir, method_data)
+        properties = visualize_scoring(image_node.get_path(), label_node.get_path(), output_dir, method_data)
 
     except Exception:
         container.logger.exception ("Exception raised, stopping job execution.")

--- a/data_processing/pathology/common/preprocess.py
+++ b/data_processing/pathology/common/preprocess.py
@@ -21,9 +21,6 @@ from skimage.color   import rgb2gray
 from skimage.filters import threshold_otsu
 from skimage.draw import rectangle_perimeter, rectangle
 
-import dill
-from io import BytesIO
-
 NUM_COLORS = 100 + 1
 scoring_palette = sns.color_palette("viridis_r", n_colors=NUM_COLORS)
 scoring_palette_as_list = [[int(x * 255) for x in scoring_palette.pop()] for i in range(NUM_COLORS)]

--- a/data_processing/pathology/common/preprocess.py
+++ b/data_processing/pathology/common/preprocess.py
@@ -143,6 +143,15 @@ def visualize_tiling_scores(df, thumbnail_img, tile_size):
 
 ### MAIN ENTRY METHOD -> pretile
 def pretile_scoring(slide_file_path: str, output_dir: str, params: dict):
+    """
+
+    Notes: 
+    to_mag_scale_factor tells us how much to scale to get from full resolution to desired magnification
+    to_thumbnail_scale_factor tells us how much to scale to get from desired mangifciation to the desired thumbnail downscale, relative to requested mag
+    
+    The tile size is defined at the requested mag, so it's bigger at full resolution and smaller for the thumbnail
+    to_mag_scale_factor and to_thumbnail_scale_factor both need to be event integers, i.e. the scale factors are multiples of the the scanned magnficiation
+    """
     logger = logging.getLogger(__name__)
 
     requested_tile_size       = params.get("tile_size")
@@ -155,10 +164,6 @@ def pretile_scoring(slide_file_path: str, output_dir: str, params: dict):
 
     logger.info("Slide size = [%s,%s]", slide.dimensions[0], slide.dimensions[1])
  
-    # to_mag_scale_factor tells us how much to scale to get from full resolution to desired magnification
-    # to_thumbnail_scale_factor tells us how much to scale to get from desired mangifciation to the desired thumbnail downscale, relative to requested mag
-    # The tile size is defined at the requested mag, so it's bigger at full resolution and smaller for the thumbnail
-    # to_mag_scale_factor and to_thumbnail_scale_factor both need to be event integers, i.e. the scale factors are multiples of the the scanned magnficiation
     scale_factor = params.get("scale_factor", 4)
     to_mag_scale_factor         = get_scale_factor_at_magnfication (slide, requested_mangification=requested_magnification)
     to_thumbnail_scale_factor   = to_mag_scale_factor * scale_factor

--- a/data_processing/pathology/common/preprocess.py
+++ b/data_processing/pathology/common/preprocess.py
@@ -155,9 +155,10 @@ def pretile_scoring(slide_file_path: str, output_dir: str, params: dict):
 
     logger.info("Slide size = [%s,%s]", slide.dimensions[0], slide.dimensions[1])
  
-    # To magnification scale factor tells us how much to scale to get from full resolution to desired mag
-    # To thumbnail scale factor tells us how much to scale to get from desired mangifciation to the desired thumbnail downscale, relative to requested mag
-    # The tile size is defined at the requested mag, so it's bigger at full resolution
+    # to_mag_scale_factor tells us how much to scale to get from full resolution to desired magnification
+    # to_thumbnail_scale_factor tells us how much to scale to get from desired mangifciation to the desired thumbnail downscale, relative to requested mag
+    # The tile size is defined at the requested mag, so it's bigger at full resolution and smaller for the thumbnail
+    # to_mag_scale_factor and to_thumbnail_scale_factor both need to be event integers, i.e. the scale factors are multiples of the the scanned magnficiation
     scale_factor = params.get("scale_factor", 4)
     to_mag_scale_factor         = get_scale_factor_at_magnfication (slide, requested_mangification=requested_magnification)
     to_thumbnail_scale_factor   = to_mag_scale_factor * scale_factor


### PR DESCRIPTION
Time to generate, visualize, and collect tiles for 52 slides, at 20x and 40x, generating 128px tiles at 10x was ~15 mins. 
```
for i in $SLIDE_IDS; do \
sleep $[ ( $RANDOM % 120 )  + 1 ]s && \
python3 -m data_processing.pathology.cli.generate_tile_labels -c TCGA-BRCA -s $i -m data_processing/pathology/cli/example_generate_tile_labels.json && \
sleep $[ ( $RANDOM % 120 )  + 1 ]s && \
python3 -m data_processing.pathology.cli.visualize_tile_labels -c TCGA-BRCA -s $i -m data_processing/pathology/cli/example_visualize_tile_labels.json && \
sleep $[ ( $RANDOM % 120 )  + 1 ]s && \
python3 -m data_processing.pathology.cli.collect_tiles -c TCGA-BRCA -s $i -m data_processing/pathology/cli/example_collect_tiles.json & done
```