### PR TITLE
add missing patient_id load_slide config

### DIFF
--- a/data_processing/pathology/cli/examples/load_slide_with_patient_id_crc.json
+++ b/data_processing/pathology/cli/examples/load_slide_with_patient_id_crc.json
@@ -1,0 +1,5 @@
+{
+    "job_tag": "crc.pathology.etl",
+    "table_path": "/gpfs/mskmindhdp_emc/data/CRC_21-167/tables/WSI_PATH_Hobbit_WSI_Colorectal_only_with_60_annotated_patientIDs", 
+    "patient_id_column_name": "patient_id"
+}


### PR DESCRIPTION
- add missing load_slide config with patient id pull from dremio