### PR TITLE
fix types and instance number

### DIFF
--- a/data_processing/radiology/common/preprocess.py
+++ b/data_processing/radiology/common/preprocess.py
@@ -247,7 +247,8 @@ def create_images(scan_path, seg_path, subset_scan_path, subset_seg_path,
 
     scans = []
     for res_slice in res:
-        image_slice = np.flipud(data[:,:,res_slice[0]])
+        image_slice = data[:,:,res_slice[0]]
+        #image_slice = np.flipud(data[:,:,res_slice[0]])
         im = slice_to_image(image_slice, width, height)
         scans.append(im)
 
@@ -262,7 +263,8 @@ def create_images(scan_path, seg_path, subset_scan_path, subset_seg_path,
 
         if crop_width and crop_height:
             dicom_binary, overlay = crop_images(res[idx][3], res[idx][4], dicom_img, overlay, crop_width, crop_height, width, height)
-
+        else:
+            overlay = overlay.tobytes()
         images.append((res[idx][2], dicom_binary, overlay))
 
     return images

--- a/data_processing/radiology/unpack_images/unpack.py
+++ b/data_processing/radiology/unpack_images/unpack.py
@@ -98,7 +98,7 @@ def binary_to_png(cfg):
         os.makedirs(image_dir, exist_ok=True)
 
         # save image to png
-        image.save(os.path.join(image_dir, str(row["metadata"]["InstanceNumber"])+".png"))
+        image.save(os.path.join(image_dir, str(index)+".png"))
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
- Don't flip the images
- Return image in bytes
- With nifti scans, we no longer have the correct instance number, so use index for PNG names.

Refinements/painpoints to address later
- Accession number parsing in proxy_table/annotation/generate assumes a data organization.
- Had to add subset_path and label column in the annotation proxy table.
- Urgh i dont like the dataset name having to be the same in the sequence -> just take in source table paths, and not construct the table names/location.